### PR TITLE
Clone doesn't protect against circular references

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ exports.extend = function (target, source, seen) {
         }
         else if (typeof orig == 'object') {
             if (seen.indexOf(orig) >= 0) {
-                // console.log('cyclic detected')
+                // Cyclic Reference Detected
             }
             else {
                 descriptor.value = exports.extend({}, orig, seen);

--- a/test/index.js
+++ b/test/index.js
@@ -73,12 +73,14 @@ describe('Hoek', function () {
         
         it('should properly clone circular reference', function (done) {
 
-            var x = {};
+            var x = {
+                'z': new Date()
+            };
             x.y = x;
             
             var b = Hoek.clone(x);
-            expect(b.y).to.equal(x);
-            expect(b.y.y).to.equal(x);
+            expect(Object.keys(b.y)).to.deep.equal(Object.keys(x))
+            expect(b.y.z).to.not.equal(x.z);
             done();
         });
         
@@ -145,6 +147,9 @@ describe('Hoek', function () {
             
             expect(x.x.c).to.not.equal(nestedObj.x.c);
             expect(x.x.c).to.not.equal(y.x.c);
+            
+            expect(x.x.c.getTime()).to.equal(nestedObj.x.c.getTime());
+            expect(x.x.c.getTime()).to.equal(y.x.c.getTime());
             done();
         });
     });


### PR DESCRIPTION
Ready for review. Coverage remains at 100%. Original test cases work. 

Notes:
- Not super clear as to the correct behavior in the circRef detection case (right now throws, but can be changed...)
- Not thread safe (assuming that's a non-issue)
- Removed the conditional parameter making this behavior optional (it crashes in the ignore case...)
- Have not tried every possible object composition but it works for the ones I tested (if anything pops up, I should be able to fix quickly)

References issue/17: 
#17
