### PR TITLE
update clone to correctly copy a Buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,10 @@ exports.clone = function (obj, seen) {
 
     for (var i in obj) {
         if (obj.hasOwnProperty(i)) {
-            if (obj[i] instanceof Date) {
+            if (obj[i] instanceof Buffer) {
+                newObj[i] = new Buffer(obj[i]);
+            }
+            else if (obj[i] instanceof Date) {
                 newObj[i] = new Date(obj[i].getTime());
             }
             else if (obj[i] instanceof RegExp) {

--- a/test/index.js
+++ b/test/index.js
@@ -183,6 +183,20 @@ describe('Hoek', function () {
             expect(b.x.z).to.equal('string in function');
             done();
         });
+
+        it('should copy a buffer', function(done){
+            var tls = {
+                key: new Buffer([1,2,3,4,5]),
+                cert: new Buffer([1,2,3,4,5,6,10])
+            }
+
+            copiedTls = Hoek.clone(tls);
+            expect(Buffer.isBuffer(copiedTls.key)).to.equal(true);
+            expect(JSON.stringify(copiedTls.key)).to.equal(JSON.stringify(tls.key))
+            expect(Buffer.isBuffer(copiedTls.cert)).to.equal(true);
+            expect(JSON.stringify(copiedTls.cert)).to.equal(JSON.stringify(tls.cert))
+            done();
+        });
     });
 
     describe('#merge', function () {


### PR DESCRIPTION
When I tried to use hapi with https, I got some weird errors- as it turns out, the problem was the way hoek copies a node Buffer.

I guess there might be other clone problems, hidden, maybe we should take a look at what other libraries do.
