### PR TITLE
Rename should throw an error for invalid property . 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -437,7 +437,7 @@ exports.loadDirModules = function (path, excludeFiles, target) {      // target(
 
 exports.rename = function (obj, from, to) {
 
-    exports.assert(obj.hasOwnProperty(from),'Invalid property '+from);
+    exports.assert(obj.hasOwnProperty(from),'Invalid property',from);
     obj[to] = obj[from];
     delete obj[from];
 };

--- a/test/index.js
+++ b/test/index.js
@@ -945,7 +945,6 @@ describe('Hoek', function () {
 
         it('should throw and invalid key in object error', function (done) {
 
-
             var fn = function () {
 
                 var obj = {a:1, b:2};


### PR DESCRIPTION
Error should be throw when rename is invoked on a property which does not exist in the object. 
This will avoid making a valid property undefined. 
e.g

``` javascript
var obj = {a: 1, b:2};
Hoek.rename(obj, 'd', 'a');  // --> Should throw an error that 'd' is not a valid property.
console.log(obj); 
// result {a:undefined, b:2}
```
