### PR TITLE
Removed substitutions for base64url decoding

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -496,7 +496,7 @@ exports.base64urlDecode = function (value, encoding) {
     }
 
     try {
-        var buf = new Buffer(value.replace(/-/g, '+').replace(/:/g, '/'), 'base64');
+        var buf = new Buffer(value, 'base64');
         return (encoding === 'buffer' ? buf : buf.toString(encoding || 'binary'));
     }
     catch (err) {


### PR DESCRIPTION
Node handles base64url decoding natively: https://github.com/joyent/node/blob/master/src/string_bytes.cc#L154
The ":" to "/" didn't really make sense in a context of the spec or the encode function. Was this a typo that went uncaught due to the native decoding of any remaining underscores?
