### PR TITLE
Default Value for Reach

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ var flattenedArray = Hoek.flatten(array, target); // results in [4, 5, 1, 2, 3]
 
 Converts an object key chain string to reference
 
+- `options` - optional settings
+    - `separator` - string to split chain path on, defaults to '.'
+    - `defaultValue` - value to return if the path or value is not present, default is `undefined`
+    - `strict` - if `true`, will throw an error on missing member, default is `false`
+    - `functions` - if `true` allow traversing functions for properties. `false` will throw an error if a function is part of the chain.
+
 ```javascript
 
 var chain = 'a.b.c';

--- a/lib/index.js
+++ b/lib/index.js
@@ -319,7 +319,7 @@ exports.reach = function (obj, chain, options) {
 
             exports.assert(!options.strict || i + 1 === il, 'Missing segment', path[i], 'in reach path ', chain);
             exports.assert(typeof ref === 'object' || options.functions === true || typeof ref !== 'function', 'Invalid segment', path[i], 'in reach path ', chain);
-            ref = undefined;
+            ref = options.defaultValue || undefined;
             break;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -810,6 +810,18 @@ describe('Hoek', function () {
 
             done();
         });
+
+        it('will return a default value if property is not found', function (done) {
+
+            expect(Hoek.reach(obj, 'a.b.q', {defaultValue: 'defaultValue'})).to.equal('defaultValue');
+            done();
+        });
+
+        it('will return a default value if path is not found', function (done) {
+
+            expect(Hoek.reach(obj, 'q', {defaultValue: 'defaultValue'})).to.equal('defaultValue');
+            done();
+        });
     });
 
     describe('#callStack', function () {
@@ -1336,4 +1348,3 @@ describe('Hoek', function () {
         });
     });
 });
-


### PR DESCRIPTION
I often see `Hoek.reach() || null` so I added the ability to supply a `defaultValue` into `reach` to use that instead of `undefined`.

I also updated the docs to reflect this change and to explain the other options `reach` accepts.
