### PR TITLE
rename defaultValue to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Converts an object key chain string to reference
 
 - `options` - optional settings
     - `separator` - string to split chain path on, defaults to '.'
-    - `defaultValue` - value to return if the path or value is not present, default is `undefined`
+    - `default` - value to return if the path or value is not present, default is `undefined`
     - `strict` - if `true`, will throw an error on missing member, default is `false`
     - `functions` - if `true` allow traversing functions for properties. `false` will throw an error if a function is part of the chain.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -319,7 +319,7 @@ exports.reach = function (obj, chain, options) {
 
             exports.assert(!options.strict || i + 1 === il, 'Missing segment', path[i], 'in reach path ', chain);
             exports.assert(typeof ref === 'object' || options.functions === true || typeof ref !== 'function', 'Invalid segment', path[i], 'in reach path ', chain);
-            ref = options.defaultValue || undefined;
+            ref = options.default || undefined;
             break;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -813,13 +813,13 @@ describe('Hoek', function () {
 
         it('will return a default value if property is not found', function (done) {
 
-            expect(Hoek.reach(obj, 'a.b.q', {defaultValue: 'defaultValue'})).to.equal('defaultValue');
+            expect(Hoek.reach(obj, 'a.b.q', {default: 'defaultValue'})).to.equal('defaultValue');
             done();
         });
 
         it('will return a default value if path is not found', function (done) {
 
-            expect(Hoek.reach(obj, 'q', {defaultValue: 'defaultValue'})).to.equal('defaultValue');
+            expect(Hoek.reach(obj, 'q', {default: 'defaultValue'})).to.equal('defaultValue');
             done();
         });
     });


### PR DESCRIPTION
Spoke to @arb about this, and he agreed. If was `defaultValue` because `default` is shown a reserved word when using jscs but there's no  limitation for key names in objects.
