### PR TITLE
Allow assert to be optimized

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -415,7 +415,7 @@ exports.assert = function (condition /*, msg1, msg2, msg3 */) {
 
     var msgs = [];
     for (var i = 1, il = arguments.length; i < il; ++i) {
-        msgs.push(arguments[i]);
+        msgs.push(arguments[i]);            // Avoids Array.slice arguments leak, allowing for V8 optimizations
     }
 
     msgs = msgs.map(function (msg) {


### PR DESCRIPTION
If you run hoek with --trace_opt you can see that the exports.assert isn't optimized because it calls slice on arguments:

```
disabled optimization for 0x1c4fd5e40f49 <SharedFunctionInfo exports.assert>, reason: Bad value context for arguments value]
```

After changing this to manually populate msgs from the arguments the function can be optimized by the optimizing compiler.
