### PR TITLE
Replaced __proto__ with Object.create()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,8 +46,7 @@ exports.clone = function (obj, seen) {
                 newObj = obj;
             }
             else {
-                newObj = {};
-                newObj.__proto__ = proto;
+                newObj = Object.create(proto);
                 cloneDeep = true;
             }
         }


### PR DESCRIPTION
**proto** is deprecated and can be replaced with Object.create().

This fix improves IE9 support (via browserify).
