### PR TITLE
Allow falsey values to be used as default value in Hoek.reach()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -319,7 +319,7 @@ exports.reach = function (obj, chain, options) {
 
             exports.assert(!options.strict || i + 1 === il, 'Missing segment', path[i], 'in reach path ', chain);
             exports.assert(typeof ref === 'object' || options.functions === true || typeof ref !== 'function', 'Invalid segment', path[i], 'in reach path ', chain);
-            ref = options.default || undefined;
+            ref = options.default;
             break;
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -854,6 +854,12 @@ describe('reach()', function () {
         expect(Hoek.reach(obj, 'q', {default: 'defaultValue'})).to.equal('defaultValue');
         done();
     });
+
+    it('allows a falsey value to be used as the default value', function (done) {
+
+        expect(Hoek.reach(obj, 'q', {default: ''})).to.equal('');
+        done();
+    });
 });
 
 describe('callStack()', function () {


### PR DESCRIPTION
Currently, values like `null` and `''` cannot be used. This commit fixes that.
