### PR TITLE
Adds ability to do Hoek.reach with negative index

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,12 +275,20 @@ Converts an object key chain string to reference
     - `strict` - if `true`, will throw an error on missing member, default is `false`
     - `functions` - if `true` allow traversing functions for properties. `false` will throw an error if a function is part of the chain.
 
+A chain including negative numbers will work like negative indices on an
+array.
+
 ```javascript
 
 var chain = 'a.b.c';
 var obj = {a : {b : { c : 1}}};
 
 Hoek.reach(obj, chain); // returns 1
+
+var chain = 'a.b.-1';
+var obj = {a : {b : [2,3,6]}};
+
+Hoek.reach(obj, chain); // returns 6
 ```
 
 ### transform(obj, transform, [options])

--- a/lib/index.js
+++ b/lib/index.js
@@ -548,10 +548,9 @@ exports.reach = function (obj, chain, options) {
 
     var path = chain.split(options.separator || '.');
     var ref = obj;
-    var hasNegative = chain.indexOf('-') !== -1;
     for (var i = 0, il = path.length; i < il; ++i) {
         var key = path[i];
-        if (hasNegative && key.indexOf('-') === 0 && Array.isArray(ref)) {
+        if (key.indexOf('-') === 0 && Array.isArray(ref)) {
             key = key.slice(1, key.length);
             key = ref.length - key;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -550,7 +550,7 @@ exports.reach = function (obj, chain, options) {
     var ref = obj;
     for (var i = 0, il = path.length; i < il; ++i) {
         var key = path[i];
-        if (key.indexOf('-') === 0 && Array.isArray(ref)) {
+        if (key[0] === '-' && Array.isArray(ref)) {
             key = key.slice(1, key.length);
             key = ref.length - key;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -548,18 +548,25 @@ exports.reach = function (obj, chain, options) {
 
     var path = chain.split(options.separator || '.');
     var ref = obj;
+    var hasNegative = chain.indexOf('-') !== -1;
     for (var i = 0, il = path.length; i < il; ++i) {
+        var key = path[i];
+        if (hasNegative && key.indexOf('-') === 0 && Array.isArray(ref)) {
+            key = key.slice(1, key.length);
+            key = ref.length - key;
+        }
+
         if (!ref ||
-            !ref.hasOwnProperty(path[i]) ||
+            !ref.hasOwnProperty(key) ||
             (typeof ref !== 'object' && options.functions === false)) {         // Only object and function can have properties
 
-            exports.assert(!options.strict || i + 1 === il, 'Missing segment', path[i], 'in reach path ', chain);
-            exports.assert(typeof ref === 'object' || options.functions === true || typeof ref !== 'function', 'Invalid segment', path[i], 'in reach path ', chain);
+            exports.assert(!options.strict || i + 1 === il, 'Missing segment', key, 'in reach path ', chain);
+            exports.assert(typeof ref === 'object' || options.functions === true || typeof ref !== 'function', 'Invalid segment', key, 'in reach path ', chain);
             ref = options.default;
             break;
         }
 
-        ref = ref[path[i]];
+        ref = ref[key];
     }
 
     return ref;

--- a/test/index.js
+++ b/test/index.js
@@ -1318,10 +1318,23 @@ describe('reach()', function () {
             }
         },
         i: function () { },
-        j: null
+        j: null,
+        k: [4, 8, 9, 1]
     };
 
     obj.i.x = 5;
+
+    it('returns first value of array', function (done) {
+
+        expect(Hoek.reach(obj, 'k.0')).to.equal(4);
+        done();
+    });
+
+    it('returns last value of array using negative index', function (done) {
+
+        expect(Hoek.reach(obj, 'k.-2')).to.equal(9);
+        done();
+    });
 
     it('returns a valid member', function (done) {
 


### PR DESCRIPTION
Fixes #114

So I did benchmark this with three different versions.

Version 1 was plain without negative index.
Version 2 used an initial check to see if there's any negative in the string, plus a negative for each part.
Version 3 just does a check for a negative for each part of the path (v2 in test)


The result was this: 

```
get with index x 3,005,799 ops/sec ±0.24% (1094 runs sampled)
get with negative index x 2,180,143 ops/sec ±0.21% (1091 runs sampled)
get with negative index v2 x 2,427,552 ops/sec ±0.25% (1094 runs sampled)
Fastest is get with index
      386.24 real       180.59 user         1.34 sys
```


See below for the code for the test. let me know if you'd like me to test it some other way, but I thought with 1000 samples something would have come up if it was significantly slower.

``` javascript

var Hoek = require('hoek');
var HoekNeg = require('hoek-neg');
var HoekNeg2 = require('hoek-neg2');
var Benchmark = require('benchmark');
var suite = new Benchmark.Suite;

var a = [1, 2, 3, 4, 5, 6, 7, 8];
suite.add('get with index', function () {


    var b = Hoek.reach(a, '0');
})

suite.add('get with negative index', function () {


    var b = HoekNeg.reach(a, '0');
})

suite.add('get with negative index v2', function () {


    var b = HoekNeg2.reach(a, '0');
})


suite.on('complete', function () {
    console.log('Fastest is ' + this.filter('fastest').pluck('name'));
});

suite.on('cycle', function (event) {
    console.log(String(event.target));
})

suite.run({ async: true, minSamples: 150, name: 'whatever'  });

```