### PR TITLE
Clone even non-enumerable properties.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,17 +61,17 @@ exports.clone = function (obj, seen) {
     seen.copy.push(newObj);
 
     if (cloneDeep) {
-        for (var i in obj) {
-            if (obj.hasOwnProperty(i)) {
-                var descriptor = Object.getOwnPropertyDescriptor(obj, i);
-                if (descriptor.get ||
-                    descriptor.set) {
+        var keys = Object.getOwnPropertyNames(obj);
+        for (var i = 0, il = keys.length; i < il; ++i) {
+            var key = keys[i];
+            var descriptor = Object.getOwnPropertyDescriptor(obj, key);
+            if (descriptor.get ||
+                descriptor.set) {
 
-                    Object.defineProperty(newObj, i, descriptor);
-                }
-                else {
-                    newObj[i] = exports.clone(obj[i], seen);
-                }
+                Object.defineProperty(newObj, key, descriptor);
+            }
+            else {
+                newObj[key] = exports.clone(obj[key], seen);
             }
         }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -331,6 +331,28 @@ describe('clone()', function () {
         expect(copy._test).to.equal(4);
         done();
     });
+
+    it('clones an object with non-enumerable properties', function (done) {
+
+        var obj = {
+            _test: 0
+        };
+
+        Object.defineProperty(obj, 'test', {
+            enumerable: false,
+            configurable: true,
+            set: function (value) {
+
+                this._test = value - 1;
+            }
+        });
+
+        var copy = Hoek.clone(obj);
+        expect(copy._test).to.equal(0);
+        copy.test = 5;
+        expect(copy._test).to.equal(4);
+        done();
+    });
 });
 
 describe('merge()', function () {
@@ -998,7 +1020,7 @@ describe('deepEqual()', function () {
 
     it('compares dates', function (done) {
 
-        expect(Hoek.deepEqual(new Date(), new Date())).to.be.true();
+        expect(Hoek.deepEqual(new Date(2015, 1, 1), new Date(2015, 1, 1))).to.be.true();
         expect(Hoek.deepEqual(new Date(100), new Date(101))).to.be.false();
         expect(Hoek.deepEqual(new Date(), {})).to.be.false();
         done();


### PR DESCRIPTION
Related to #128.

This also includes a potential fix for io.js CI.