### PR TITLE
Added option parameter to deepEqual.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,14 @@ var options = { server: { port: 8080 } };
 var config = Hoek.applyToDefaults(defaults, options); // results in { server: { port: 8080 }, name: 'example' }
 ```
 
-### deepEqual(b, a)
+### deepEqual(b, a, [options])
 
-Performs a deep comparison of the two values including support for circular dependencies, prototype, and properties.
+Performs a deep comparison of the two values including support for circular dependencies, prototype, and properties. To skip prototype comparisons, use `options.prototype = false`
 
 ```javascript
-Hoek.deepEqual({ a: [1, 2], b: 'string', c: { d: true } }, { a: [1, 2], b: 'string', c: { d: true } });
+Hoek.deepEqual({ a: [1, 2], b: 'string', c: { d: true } }, { a: [1, 2], b: 'string', c: { d: true } }); //results in true
+Hoek.deepEqual(Object.create(null), {}, { prototype: false }); //results in true
+Hoek.deepEqual(Object.create(null), {}); //results in false
 ```
 
 ### unique(array, key)
@@ -499,7 +501,7 @@ nextFn();
 console.log('Do this first');
 
 // Results in:
-// 
+//
 // Do this first
 // Do this later
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,9 +81,9 @@ exports.clone = function (obj, seen) {
 
 
 // Merge all the properties of source into target, source wins in conflict, and by default null and undefined from source are applied
-
+/*eslint-disable */
 exports.merge = function (target, source, isNullOverride /* = true */, isMergeArrays /* = true */) {
-
+/*eslint-enable */
     exports.assert(target && typeof target === 'object', 'Invalid target value: must be an object');
     exports.assert(source === null || source === undefined || typeof source === 'object', 'Invalid source value: must be null, undefined, or an object');
 
@@ -247,9 +247,12 @@ exports.applyToDefaultsWithShallow = function (defaults, options, keys) {
 
 // Deep object or array comparison
 
-exports.deepEqual = function (obj, ref, seen) {
+exports.deepEqual = function (obj, ref, options, seen) {
+
+    options = options || { prototype: true };
 
     var type = typeof obj;
+
     if (type !== typeof ref) {
         return false;
     }
@@ -316,8 +319,10 @@ exports.deepEqual = function (obj, ref, seen) {
         return (ref instanceof RegExp && obj.toString() === ref.toString());
     }
 
-    if (Object.getPrototypeOf(obj) !== Object.getPrototypeOf(ref)) {
-        return false;
+    if (options.prototype) {
+        if (Object.getPrototypeOf(obj) !== Object.getPrototypeOf(ref)) {
+            return false;
+        }
     }
 
     var keys = Object.getOwnPropertyNames(obj);
@@ -330,11 +335,11 @@ exports.deepEqual = function (obj, ref, seen) {
         var key = keys[k];
         var descriptor = Object.getOwnPropertyDescriptor(obj, key);
         if (descriptor.get) {
-            if (!exports.deepEqual(descriptor, Object.getOwnPropertyDescriptor(ref, key), seen)) {
+            if (!exports.deepEqual(descriptor, Object.getOwnPropertyDescriptor(ref, key), options, seen)) {
                 return false;
             }
         }
-        else if (!exports.deepEqual(obj[key], ref[key], seen)) {
+        else if (!exports.deepEqual(obj[key], ref[key], options, seen)) {
             return false;
         }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -1161,6 +1161,15 @@ describe('deepEqual()', function () {
         expect(Hoek.deepEqual(a, {})).to.be.false();
         done();
     });
+
+    it('compares an object ignoring the prototype', function (done) {
+
+        var a = Object.create(null);
+        var b = {};
+
+        expect(Hoek.deepEqual(a, b, { prototype: false})).to.be.true();
+        done();
+    });
 });
 
 describe('unique()', function () {


### PR DESCRIPTION
- Cleaned up some lint issues
- Added `options` to deep equal. Currently only useful for prototype ignoring.
- Updated docs.

## Motivation

It would be nice when testing to be able to compare `Object.create(null)` to `{}`. Pertinent io [pull request] (https://github.com/iojs/io.js/pull/772#discussion_r24360159]).