### PR TITLE
Allow for deep partial contain

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -280,12 +280,24 @@ exports.deepEqual = function (obj, ref, options, seen) {
             return false;
         }
 
-        if (obj.length !== ref.length) {
+        if (!options.part && obj.length !== ref.length) {
             return false;
         }
 
         for (var i = 0, il = obj.length; i < il; ++i) {
-            if (!exports.deepEqual(obj[i], ref[i], options)) {
+            if (options.part) {
+                var found = false;
+                for (var r = 0, rl = ref.length; r < rl; ++r) {
+                    if (exports.deepEqual(obj[i], ref[r], options, seen)) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                return found;
+            }
+
+            if (!exports.deepEqual(obj[i], ref[i], options, seen)) {
                 return false;
             }
         }
@@ -327,7 +339,7 @@ exports.deepEqual = function (obj, ref, options, seen) {
 
     var keys = Object.getOwnPropertyNames(obj);
 
-    if (keys.length !== Object.getOwnPropertyNames(ref).length) {
+    if (!options.part && keys.length !== Object.getOwnPropertyNames(ref).length) {
         return false;
     }
 
@@ -448,7 +460,20 @@ exports.contain = function (ref, values, options) {
     exports.assert(typeof ref === 'string' || typeof ref === 'object', 'Reference must be string or an object');
     exports.assert(values.length, 'Values array cannot be empty');
 
-    var compare = options.deep ? exports.deepEqual : function (a, b) { return a === b; };
+    var compare, compareFlags;
+    if (options.deep) {
+        compare = exports.deepEqual;
+
+        var hasOnly = options.hasOwnProperty('only'), hasPart = options.hasOwnProperty('part');
+
+        compareFlags = {
+            prototype: hasOnly ? options.only : hasPart ? !options.part : false,
+            part: hasOnly ? !options.only : hasPart ? options.part : true
+        };
+    }
+    else {
+        compare = function (a, b) { return a === b; };
+    }
 
     var misses = false;
     var matches = new Array(values.length);
@@ -477,7 +502,7 @@ exports.contain = function (ref, values, options) {
     else if (Array.isArray(ref)) {
         for (i = 0, il = ref.length; i < il; ++i) {
             for (var j = 0, jl = values.length, matched = false; j < jl && matched === false; ++j) {
-                matched = compare(ref[i], values[j]) && j;
+                matched = compare(values[j], ref[i], compareFlags) && j;
             }
 
             if (matched !== false) {
@@ -495,7 +520,7 @@ exports.contain = function (ref, values, options) {
             var pos = values.indexOf(key);
             if (pos !== -1) {
                 if (valuePairs &&
-                    !compare(ref[key], valuePairs[key])) {
+                    !compare(valuePairs[key], ref[key], compareFlags)) {
 
                     return false;
                 }

--- a/test/index.js
+++ b/test/index.js
@@ -1348,6 +1348,11 @@ describe('contain()', function () {
         expect(Hoek.contain({ a: 1, b: 2, c: 3 }, { a: 1, d: 4 }, { part: true })).to.be.true();
         expect(Hoek.contain({ a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3 }, { only: true })).to.be.true();
         expect(Hoek.contain({ a: [1], b: [2], c: [3] }, { a: [1], c: [3] }, { deep: true })).to.be.true();
+        expect(Hoek.contain({ a: [{ b: 1 }, { c: 2 }, { d: 3, e: 4 }] }, { a: [{ b: 1 }, { d: 3 }] }, { deep: true })).to.be.true();
+        expect(Hoek.contain({ a: [{ b: 1 }, { c: 2 }, { d: 3, e: 4 }] }, { a: [{ b: 1 }, { d: 3 }] }, { deep: true, part: true })).to.be.true();
+        expect(Hoek.contain({ a: [{ b: 1 }, { c: 2 }, { d: 3, e: 4 }] }, { a: [{ b: 1 }, { d: 3 }] }, { deep: true, part: false })).to.be.false();
+        expect(Hoek.contain({ a: [{ b: 1 }, { c: 2 }, { d: 3, e: 4 }] }, { a: [{ b: 1 }, { d: 3 }] }, { deep: true, only: true })).to.be.false();
+        expect(Hoek.contain({ a: [{ b: 1 }, { c: 2 }, { d: 3, e: 4 }] }, { a: [{ b: 1 }, { d: 3 }] }, { deep: true, only: false })).to.be.true();
 
         expect(Hoek.contain({ a: 1, b: 2, c: 3 }, 'd')).to.be.false();
         expect(Hoek.contain({ a: 1, b: 2, c: 3 }, ['a', 'd'])).to.be.false();
@@ -1358,6 +1363,32 @@ describe('contain()', function () {
         expect(Hoek.contain({ a: 1, b: 2, c: 3 }, { a: 1, d: 4 })).to.be.false();
         expect(Hoek.contain({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 }, { only: true })).to.be.false();
         expect(Hoek.contain({ a: [1], b: [2], c: [3] }, { a: [1], c: [3] })).to.be.false();
+        expect(Hoek.contain({ a: { b: { c: 1, d: 2 }}}, { a: { b: { c: 1 }}})).to.be.false();
+        expect(Hoek.contain({ a: { b: { c: 1, d: 2 }}}, { a: { b: { c: 1 }}}, { deep: true })).to.be.true();
+        expect(Hoek.contain({ a: { b: { c: 1, d: 2 }}}, { a: { b: { c: 1 }}}, { deep: true, only: true })).to.be.false();
+        expect(Hoek.contain({ a: { b: { c: 1, d: 2 }}}, { a: { b: { c: 1 }}}, { deep: true, only: false })).to.be.true();
+        expect(Hoek.contain({ a: { b: { c: 1, d: 2 }}}, { a: { b: { c: 1 }}}, { deep: true, part: true })).to.be.true();
+        expect(Hoek.contain({ a: { b: { c: 1, d: 2 }}}, { a: { b: { c: 1 }}}, { deep: true, part: false })).to.be.false();
+
+        // Getter check
+        var Foo = function(bar) {
+
+            this.bar = bar;
+        };
+        Object.defineProperty(Foo.prototype, 'baz', {
+            enumerable: true,
+            get: function () {
+                return this.bar;
+            }
+        });
+
+        expect(Hoek.contain({ a: new Foo('b') }, { a: new Foo('b') }, { deep: true })).to.be.true();
+        expect(Hoek.contain({ a: new Foo('b') }, { a: new Foo('b') }, { deep: true, part: true })).to.be.true();
+        expect(Hoek.contain({ a: new Foo('b') }, { a: { baz: 'b' }}, { deep: true })).to.be.true();
+        expect(Hoek.contain({ a: new Foo('b') }, { a: { baz: 'b' }}, { deep: true, only: true })).to.be.false();
+        expect(Hoek.contain({ a: new Foo('b') }, { a: { baz: 'b' }}, { deep: true, part: false })).to.be.false();
+        expect(Hoek.contain({ a: new Foo('b') }, { a: { baz: 'b' }}, { deep: true, part: true })).to.be.true();
+
         done();
     });
 });


### PR DESCRIPTION
This changes the behavior of contain to be able to deeply find properties without having an exact deep match.

Note that I'm still wondering why L288 didn't transmit its options and seen, it doesn't seem to change anything to the tests but I added it anyway.