### PR TITLE
Updating license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,5 @@
   "scripts": {
     "test": "make test-cov"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://github.com/hapijs/hoek/raw/master/LICENSE"
-    }
-  ]
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/