### PR TITLE
Enhancement: Make contain see non-enumerable's

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -528,7 +528,7 @@ exports.contain = function (ref, values, options) {
         }
     }
     else {
-        const keys = Object.keys(ref);
+        const keys = Object.getOwnPropertyNames(ref);
         for (let i = 0; i < keys.length; ++i) {
             const key = keys[i];
             const pos = values.indexOf(key);


### PR DESCRIPTION
The contain method would previously fail to see non-enumerable
properties. This change was performed by changing `Object.keys` for
`Object.getOwnPropertyNames`.

Also, added a bunch of extra assertions in the `contain() tests objects`
test for:

* Assert that `contains` returns false on inherited members
* Assert that `contains` returns true on non-enumerable members on the
object

Fixes: #196