### PR TITLE
Fix isInteger for unsafe integers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -878,12 +878,7 @@ exports.once = function (method) {
 };
 
 
-exports.isInteger = function (value) {
-
-    return (typeof value === 'number' &&
-            parseFloat(value) === parseInt(value, 10) &&
-            !isNaN(value));
-};
+exports.isInteger = Number.isSafeInteger;
 
 
 exports.ignore = function () { };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "code": "3.x.x",
-    "lab": "10.x.x"
+    "code": "4.x.x",
+    "lab": "13.x.x"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",

--- a/test/index.js
+++ b/test/index.js
@@ -2222,6 +2222,8 @@ describe('isInteger()', () => {
         expect(Hoek.isInteger('0')).to.equal(false);
         expect(Hoek.isInteger(1.0)).to.equal(true);
         expect(Hoek.isInteger(1.1)).to.equal(false);
+        expect(Hoek.isInteger(90071992547409910.1)).to.equal(false);
+        expect(Hoek.isInteger(NaN)).to.equal(false);
         done();
     });
 });


### PR DESCRIPTION
Relates to https://github.com/hapijs/joi/issues/1143.

I removed the `isNaN` check because it was already checked by the previous line `NaN !== NaN`.