### PR TITLE
Throw instances of AssertionError on asserts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,9 +2,11 @@
 
 // Load modules
 
+const Assert = require('assert');
 const Crypto = require('crypto');
 const Path = require('path');
 const Util = require('util');
+
 const Escape = require('./escape');
 
 
@@ -727,7 +729,13 @@ exports.assert = function (condition, ...args) {
             return typeof arg === 'string' ? arg : arg instanceof Error ? arg.message : exports.stringify(arg);
         });
 
-    throw new Error(msgs.join(' ') || 'Unknown error');
+    throw new Assert.AssertionError({
+        message: msgs.join(' ') || 'Unknown error',
+        actual: false,
+        expected: true,
+        operator: '==',
+        stackStartFunction: exports.assert
+    });
 };
 
 


### PR DESCRIPTION
This allows `try/catch` clauses to detect these errors, and handle them separately. Most importantly, it can be handled by https://github.com/hapijs/bounce.

Note that this changes the `err.name` property, and the associated `toString()` output:

```
Error: My message
```

becomes

```
AssertionError [ERR_ASSERTION]: My message
```