### PR TITLE
Backport proto fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,10 @@ exports.merge = function (target, source, isNullOverride /* = true */, isMergeAr
     const keys = Object.keys(source);
     for (let i = 0; i < keys.length; ++i) {
         const key = keys[i];
+        if (key === '__proto__') {
+            continue;
+        }
+
         const value = source[key];
         if (value &&
             typeof value === 'object') {

--- a/test/index.js
+++ b/test/index.js
@@ -615,13 +615,14 @@ describe('merge()', () => {
         done();
     });
 
-    it('skips __proto__', () => {
+    it('skips __proto__', (done) => {
 
         const a = '{ "ok": "value", "__proto__": { "test": "value" } }';
 
         const b = Hoek.merge({}, JSON.parse(a));
         expect(b).to.equal({ ok: 'value' });
         expect(b.test).to.equal(undefined);
+        done();
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -614,6 +614,15 @@ describe('merge()', () => {
         expect(a.x.toString()).to.equal('abc');
         done();
     });
+
+    it('skips __proto__', () => {
+
+        const a = '{ "ok": "value", "__proto__": { "test": "value" } }';
+
+        const b = Hoek.merge({}, JSON.parse(a));
+        expect(b).to.equal({ ok: 'value' });
+        expect(b.test).to.equal(undefined);
+    });
 });
 
 describe('applyToDefaults()', () => {


### PR DESCRIPTION
Fixes #230.

Travis failure is because of new node leaks, nothing to worry about.