### PR TITLE
Backport 'skip assignment to __proto__' to v2.x.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,11 @@ exports.merge = function (target, source, isNullOverride /* = true */, isMergeAr
     var keys = Object.keys(source);
     for (var k = 0, kl = keys.length; k < kl; ++k) {
         var key = keys[k];
+        if (key === '__proto__') {
+            continue;
+        }
         var value = source[key];
+
         if (value &&
             typeof value === 'object') {
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hoek",
   "description": "General purpose node utilities",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "repository": "git://github.com/hapijs/hoek",
   "main": "lib/index.js",
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -589,6 +589,17 @@ describe('merge()', function () {
         expect(a.x.toString()).to.equal('abc');
         done();
     });
+
+    it('skips __proto__', (done) => {
+
+        var a = JSON.parse('{ "ok": "value", "__proto__": { "test": "value" } }');
+        var b = Hoek.merge({}, a);
+
+        expect(Object.keys(b).length).to.equal(1);
+        expect(Object.keys(b)[0]).to.equal('ok');
+        expect(b.test).to.equal(undefined);
+        done();
+    });
 });
 
 describe('applyToDefaults()', function () {


### PR DESCRIPTION
Hej hej! I've tried my hand at backporting the [__proto__ vuln fix](https://github.com/hapijs/hoek/pull/231/) to v2.x.x! 😇

Our project seems to have a lot of dependencies pointing at v2.x.x versions of this package so this seems like it might be the fastest way to resolve the vulnerability from our perspective! Let me know what you think though.

If you look real close at the unit test you'll see it actually makes slightly different assertions than the tests added for the v4.x.x version of the fix. For some reason I couldn't get the v4.x.x test to pass so I tweaked it slightly until it worked. Here are the assertions side-by-side so that you can easily compare.

| v4.x.x | v2.x.x |
|--------|------|
| expect(b).to.equal({ ok: 'value' }); | expect(Object.keys(b).length).to.equal(1); |
| expect(b.test).to.equal(undefined); | expect(Object.keys(b)[0]).to.equal('ok'); |
| | expect(b.test).to.equal(undefined); |

Hope this is okay but let me know if not, or if you need anything more! ❤️ 