### PR TITLE
Use Object.assign() for shallow() implementation

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,7 +16,7 @@
   * [reach](#reachobj-chain-options "reach")
   * [reachTemplate](#reachtemplateobj-template-options "reachTemplate")
   * [transform](#transformobj-transform-options "transform")
-  * [shallow](#shallowobj "shallow")
+  * [shallow](#shallowsource "shallow")
   * [stringify](#stringifyobj "stringify")
 * [Bench](#bench "Bench")
 * [Binary Encoding/Decoding](#binary-encodingdecoding "Binary Encoding/Decoding")
@@ -331,10 +331,10 @@ var result = Hoek.transform(source, {
 // }
 ```
 
-### shallow(obj)
+### shallow(source)
 
-Performs a shallow copy by copying the references of all the top level children where:
-- `obj` - the object to be copied.
+Returns a new object with shallow copies of all source properties where:
+- `source` - the source to be copied.
 
 ```javascript
 var shallow = Hoek.shallow({ a: { b: 1 } });

--- a/lib/index.js
+++ b/lib/index.js
@@ -938,14 +938,7 @@ exports.stringify = function (...args) {
 
 exports.shallow = function (source) {
 
-    const target = {};
-    const keys = Object.keys(source);
-    for (let i = 0; i < keys.length; ++i) {
-        const key = keys[i];
-        target[key] = source[key];
-    }
-
-    return target;
+    return Object.assign({}, source);
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -2370,6 +2370,25 @@ describe('shallow()', () => {
         expect(shallow).to.equal(obj);
         expect(shallow.b).to.equal(obj.b);
     });
+
+    it('copies properties from a function', () => {
+
+        const fn = function () { };
+        fn.a = 5;
+        fn.b = { c: 6 };
+
+        const shallow = Hoek.shallow(fn);
+        expect(shallow).to.be.an.object();
+        expect(shallow).to.not.shallow.equal(fn);
+        expect(Object.entries(shallow)).to.equal(Object.entries(fn));
+        expect(shallow.b).to.equal(fn.b);
+    });
+
+    it('returns empty object for null and undefined', () => {
+
+        expect(Hoek.shallow(null)).to.equal({});
+        expect(Hoek.shallow(undefined)).to.equal({});
+    });
 });
 
 describe('block()', () => {


### PR DESCRIPTION
Afaik, the result should be the same for all inputs.