### PR TITLE
Make deepEqual's seen consider both sides of the comparison

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -281,12 +281,13 @@ exports.deepEqual = function (obj, ref, options, seen) {
     }
 
     seen = seen || new Map();
-    if (seen.has(obj)) {
-        if (seen.get(obj).has(ref)) {
+    const seenSet = seen.get(obj);
+    if (seenSet) {
+        if (seenSet.has(ref)) {
             return true;                            // If previous comparison failed, it would have stopped execution
         }
 
-        seen.get(obj).add(ref);
+        seenSet.add(ref);
     }
     else {
         seen.set(obj, new Set([ref]));

--- a/lib/index.js
+++ b/lib/index.js
@@ -280,12 +280,17 @@ exports.deepEqual = function (obj, ref, options, seen) {
         return obj !== obj && ref !== ref;                  // NaN
     }
 
-    seen = seen || [];
-    if (seen.indexOf(obj) !== -1) {
-        return true;                            // If previous comparison failed, it would have stopped execution
-    }
+    seen = seen || new Map();
+    if (seen.has(obj)) {
+        if (seen.get(obj).has(ref)) {
+            return true;                            // If previous comparison failed, it would have stopped execution
+        }
 
-    seen.push(obj);
+        seen.get(obj).add(ref);
+    }
+    else {
+        seen.set(obj, new Set([ref]));
+    }
 
     if (Array.isArray(obj)) {
         if (!Array.isArray(ref)) {

--- a/test/index.js
+++ b/test/index.js
@@ -1096,6 +1096,14 @@ describe('deepEqual()', () => {
         expect(Hoek.deepEqual(a, b)).to.be.true();
     });
 
+    it('handles reuse of objects', () => {
+
+        const date1 = { year: 2018, month: 1, day: 1 };
+        const date2 = { year: 2000, month: 1, day: 1 };
+
+        expect(Hoek.deepEqual({ start: date1, end: date1 }, { start: date1, end: date2 })).to.be.false();
+    });
+
     it('compares an object with property getter without executing it', () => {
 
         const obj = {};


### PR DESCRIPTION
Fixes #236.

Ideally we should probably compare those as couples, I could make a reverse lookup but I'm not sure it's necessary.