### PR TITLE
Added Map/Set and Promise as cloneable objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,24 +47,16 @@ exports.clone = function (obj, seen) {
         }
         else if (obj instanceof Set) {
             newObj = new Set();
+            cloneDeep = true;
             for (const val of obj) {
-                if (typeof val === 'object') {
-                    newObj.add(exports.clone(val));
-                    cloneDeep = true;
-                }
-                else {
-                    newObj.add(val);
-                }
+                newObj.add(exports.clone(val));
             }
         }
         else if (obj instanceof Map) {
             newObj = new Map();
+            cloneDeep = true;
             for (let [key, value] of obj) {
-                if (typeof value === 'object') {
-                    value = exports.clone(value);
-                    cloneDeep = true;
-                }
-
+                value = exports.clone(value);
                 newObj.set(key, value);
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,10 +58,7 @@ exports.clone = function (obj, seen) {
             }
         }
         else if (obj instanceof Promise) {
-            newObj = obj.then(
-                (success) => (success),
-                (err) => (err)
-            );
+            newObj = obj.then();
         }
         else {
             const proto = Object.getPrototypeOf(obj);

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,12 @@ exports.clone = function (obj, seen) {
                 }
             }
         }
+        else if (obj instanceof Promise) {
+            newObj = obj.then(
+                (success) => (success),
+                (err) => (err)
+            );
+        }
         else {
             const proto = Object.getPrototypeOf(obj);
             if (proto &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,18 @@ exports.clone = function (obj, seen) {
         else if (obj instanceof RegExp) {
             newObj = new RegExp(obj);
         }
+        else if (obj instanceof Set) {
+            newObj = new Set();
+            const vals = Array.from(obj);
+            for (let i = 0; i < vals.length; ++i) {
+                if (typeof vals[i] === 'object') {
+                    newObj.add(exports.clone(vals[i]));
+                }
+                else {
+                    newObj.add(vals[i]);
+                }
+            }
+        }
         else {
             const proto = Object.getPrototypeOf(obj);
             if (proto &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ exports.clone = function (obj, seen) {
             }
         }
         else if (obj instanceof Promise) {
-            newObj = obj.then();
+            newObj = obj.then((success) => exports.clone(success), (err) => exports.clone(err));
         }
         else {
             const proto = Object.getPrototypeOf(obj);

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,17 @@ exports.clone = function (obj, seen) {
                 }
             }
         }
+        else if (obj instanceof Map) {
+            newObj = new Map();
+            const entries = Array.from(obj);
+            for (let i = 0; i < entries.length; ++i) {
+                let [key, value] = entries[i];
+                if (typeof value === 'object') {
+                    value = exports.clone(value);
+                }
+                newObj.set(key, value);
+            }
+        }
         else if (obj instanceof Promise) {
             newObj = obj.then();
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,7 @@ exports.clone = function (obj, seen) {
                     value = exports.clone(value);
                     cloneDeep = true;
                 }
+
                 newObj.set(key, value);
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,11 +59,10 @@ exports.clone = function (obj, seen) {
         }
         else if (obj instanceof Map) {
             newObj = new Map();
-            const entries = Array.from(obj);
-            for (let i = 0; i < entries.length; ++i) {
-                let [key, value] = entries[i];
+            for (let [key, value] of obj) {
                 if (typeof value === 'object') {
                     value = exports.clone(value);
+                    cloneDeep = true;
                 }
                 newObj.set(key, value);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,13 +47,13 @@ exports.clone = function (obj, seen) {
         }
         else if (obj instanceof Set) {
             newObj = new Set();
-            const vals = Array.from(obj);
-            for (let i = 0; i < vals.length; ++i) {
-                if (typeof vals[i] === 'object') {
-                    newObj.add(exports.clone(vals[i]));
+            for (const val of obj) {
+                if (typeof val === 'object') {
+                    newObj.add(exports.clone(val));
+                    cloneDeep = true;
                 }
                 else {
-                    newObj.add(vals[i]);
+                    newObj.add(val);
                 }
             }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -464,7 +464,45 @@ describe('clone()', () => {
             });
         });
     });
+
+    it('clones Maps', () => {
+
+        const a = new Map();
+        a.set('a', 1);
+        a.set('b', 2);
+        a.set('c', 3);
+
+        const b = Hoek.clone(a);
+
+        expect(a).to.equal(b);
+    });
+
+    it('clones Maps containing objects as values (no pass by reference)', () => {
+
+        const a = new Map();
+        a.set('a', 1);
+        a.set('b', 2);
+        a.set('c', nestedObj);
+
+        const b = Hoek.clone(a);
+        const result = a.get('c') === b.get('c');
+        expect(result).to.equal(false);
+    });
+
+    it('clones Maps containing objects as keys (are passed by reference)', () => {
+
+        const a = new Map();
+        a.set('a', 1);
+        a.set('b', 2);
+        a.set(nestedObj, 3);
+
+        const b = Hoek.clone(a);
+        const result = a.get(nestedObj) === b.get(nestedObj);
+        expect(result).to.equal(true);
+    });
 });
+
+
 
 describe('merge()', () => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -391,6 +391,25 @@ describe('clone()', () => {
         const copy = Hoek.clone(obj);
         expect(copy).to.equal(obj);
     });
+
+    it('clones sets', () => {
+
+        const a = new Set([1, 2, 3]);
+
+        const b = Hoek.clone(a);
+
+        expect(a).to.equal(b);
+    });
+
+    it('clones sets containing objects (no pass by reference)', () => {
+
+        const a = new Set([1, 2, 3]);
+        a.add(nestedObj);
+
+        const b = Hoek.clone(a);
+
+        expect(b.has(nestedObj)).to.equal(false);
+    });
 });
 
 describe('merge()', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -398,7 +398,8 @@ describe('clone()', () => {
 
         const b = Hoek.clone(a);
 
-        expect(a).to.equal(b);
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
     });
 
     it('clones sets containing objects (no pass by reference)', () => {
@@ -408,7 +409,8 @@ describe('clone()', () => {
 
         const b = Hoek.clone(a);
 
-        expect(b.has(nestedObj)).to.equal(false);
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
     });
 
     it('clones Promises', () => {
@@ -474,7 +476,7 @@ describe('clone()', () => {
 
         const b = Hoek.clone(a);
 
-        expect(a).to.equal(b);
+        expect(b).to.not.shallow.equal(new Map([['a', 1], ['b', 2], ['c', 3]]));
     });
 
     it('clones Maps containing objects as values (no pass by reference)', () => {
@@ -485,8 +487,9 @@ describe('clone()', () => {
         a.set('c', nestedObj);
 
         const b = Hoek.clone(a);
-        const result = a.get('c') === b.get('c');
-        expect(result).to.equal(false);
+
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
     });
 
     it('clones Maps containing objects as keys (are passed by reference)', () => {
@@ -497,8 +500,9 @@ describe('clone()', () => {
         a.set(nestedObj, 3);
 
         const b = Hoek.clone(a);
-        const result = a.get(nestedObj) === b.get(nestedObj);
-        expect(result).to.equal(true);
+
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -425,7 +425,7 @@ describe('clone()', () => {
         expect(a).to.equal(b);
     });
 
-    it('cloned Promises should resolve like original promise', () => {
+    it('clone objects resolved by the function (no pass by reference)', () => {
 
         const a = new Promise((resolve, reject) => {
 
@@ -441,12 +441,12 @@ describe('clone()', () => {
             b.then((successTwo) => {
 
                 expect(successOne).to.equal(successTwo);
-                expect(successOne === successTwo).to.equal(true);
+                expect(successOne === successTwo).to.equal(false);
             });
         });
     });
 
-    it('cloned Promises should reject like original promise', () => {
+    it('clone objects rejects by the function (no pass by reference)', () => {
 
         const a = new Promise((resolve, reject) => {
 
@@ -462,7 +462,7 @@ describe('clone()', () => {
             b.catch((errTwo) => {
 
                 expect(errOne).to.equal(errTwo);
-                expect(errOne === errTwo).to.equal(true);
+                expect(errOne === errTwo).to.equal(false);
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -506,8 +506,6 @@ describe('clone()', () => {
     });
 });
 
-
-
 describe('merge()', () => {
 
     it('deep copies source items', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -422,6 +422,48 @@ describe('clone()', () => {
 
         expect(a).to.equal(b);
     });
+
+    it('cloned Promises should resolve like original promise', () => {
+
+        const a = new Promise((resolve, reject) => {
+
+            setTimeout(() => {
+
+                resolve({ 'a':1, 'b':2 });
+            }, 0);
+        });
+
+        const b = Hoek.clone(a);
+        a.then((successOne) => {
+
+            b.then((successTwo) => {
+
+                expect(successOne).to.equal(successTwo);
+                expect(successOne === successTwo).to.equal(true);
+            });
+        });
+    });
+
+    it('cloned Promises should reject like original promise', () => {
+
+        const a = new Promise((resolve, reject) => {
+
+            setTimeout(() => {
+
+                reject({ 'a':1, 'b':2 });
+            }, 0);
+        });
+
+        const b = Hoek.clone(a);
+        a.catch((errOne) => {
+
+            b.catch((errTwo) => {
+
+                expect(errOne).to.equal(errTwo);
+                expect(errOne === errTwo).to.equal(true);
+            });
+        });
+    });
 });
 
 describe('merge()', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -410,6 +410,18 @@ describe('clone()', () => {
 
         expect(b.has(nestedObj)).to.equal(false);
     });
+
+    it('clones Promises', () => {
+
+        const a = new Promise((resolve, reject) => {
+
+            setTimeout(resolve, 0);
+        });
+
+        const b = Hoek.clone(a);
+
+        expect(a).to.equal(b);
+    });
 });
 
 describe('merge()', () => {


### PR DESCRIPTION
I decided to not duplicate Map keys if the key was an object, and instead pass by reference to preserve the ability to use getters.