### PR TITLE
 Add reach options.operate for lazy ref calculate in joi

### DIFF
--- a/API.md
+++ b/API.md
@@ -262,6 +262,7 @@ Converts an object key chain string to reference
     - `default` - value to return if the path or value is not present, default is `undefined`
     - `strict` - if `true`, will throw an error on missing member, default is `false`
     - `functions` - if `true` allow traversing functions for properties. `false` will throw an error if a function is part of the chain.
+    - `operate` - if operate is a function with argument (ref, key), it will return the function result. Else if operate is a value, it will set this value to ref[key], and return the old value.
 
 A chain including negative numbers will work like negative indices on an
 array.
@@ -279,6 +280,17 @@ var chain = 'a.b.-1';
 var obj = {a : {b : [2,3,6]}};
 
 Hoek.reach(obj, chain); // returns 6
+
+var chain = 'a.b.-1';
+var obj = {a : {b : [2,3,6]}};
+
+Hoek.reach(obj, chain, { operate: (ref, key) => ref[key] + 1 }); // returns 7
+
+var chain = 'a.b.-1';
+var obj = {a : {b : [2,3,6]}};
+
+Hoek.reach(obj, chain, { operate: 8 }); // returns 6
+Hoek.reach(obj, chain); // returns 8, has changed to 8
 ```
 
 ### reachTemplate(obj, template, [options])

--- a/lib/index.js
+++ b/lib/index.js
@@ -592,6 +592,7 @@ exports.flatten = function (array, target) {
 
 
 // Convert an object key chain string ('a.b.c') to reference (object[a][b][c])
+// if operate is set, transform the reached reference and return
 
 exports.reach = function (obj, chain, options) {
 
@@ -626,52 +627,17 @@ exports.reach = function (obj, chain, options) {
             break;
         }
 
-        ref = ref[key];
-    }
-
-    return ref;
-};
-
-// reach the reference of (object[a][b][c]) and transform it.
-
-exports.reachTransform = function (obj, chain, operate, options) {
-
-    if (chain === false ||
-        chain === null ||
-        typeof chain === 'undefined') {
-
-        return obj;
-    }
-
-    options = options || {};
-    if (typeof options === 'string') {
-        options = { separator: options };
-    }
-
-    const path = chain.split(options.separator || '.');
-    let ref = obj;
-    for (let i = 0; i < path.length; ++i) {
-        let key = path[i];
-        if (key[0] === '-' && Array.isArray(ref)) {
-            key = key.slice(1, key.length);
-            key = ref.length - key;
-        }
-
-        if (!ref ||
-            !((typeof ref === 'object' || typeof ref === 'function') && key in ref) ||
-            (typeof ref !== 'object' && options.functions === false)) {         // Only object and function can have properties
-
-            exports.assert(!options.strict || i + 1 === path.length, 'Missing segment', key, 'in reach path ', chain);
-            exports.assert(typeof ref === 'object' || options.functions === true || typeof ref !== 'function', 'Invalid segment', key, 'in reach path ', chain);
-            ref = options.default;
-            break;
-        }
-
-        if (i < path.length - 1) {
+        if (i < path.length - 1 || !options.operate) {
             ref = ref[key];
         }
         else {
-            ref = ref[key] = operate(ref[key]);
+            const operate = options.operate;
+            if (typeof operate === 'function') {
+                ref = ref[key] = operate(ref[key]);
+            }
+            else {
+                ref = ref[key] = operate;
+            }
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -633,10 +633,12 @@ exports.reach = function (obj, chain, options) {
         else {
             const operate = options.operate;
             if (typeof operate === 'function') {
-                ref = ref[key] = operate(ref[key]);
+                ref = operate(ref, key);
             }
             else {
-                ref = ref[key] = operate;
+                const old = ref[key];
+                ref[key] = operate;
+                ref = old;
             }
         }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -632,6 +632,52 @@ exports.reach = function (obj, chain, options) {
     return ref;
 };
 
+// reach the reference of (object[a][b][c]) and transform it.
+
+exports.reachTransform = function (obj, chain, operate, options) {
+
+    if (chain === false ||
+        chain === null ||
+        typeof chain === 'undefined') {
+
+        return obj;
+    }
+
+    options = options || {};
+    if (typeof options === 'string') {
+        options = { separator: options };
+    }
+
+    const path = chain.split(options.separator || '.');
+    let ref = obj;
+    for (let i = 0; i < path.length; ++i) {
+        let key = path[i];
+        if (key[0] === '-' && Array.isArray(ref)) {
+            key = key.slice(1, key.length);
+            key = ref.length - key;
+        }
+
+        if (!ref ||
+            !((typeof ref === 'object' || typeof ref === 'function') && key in ref) ||
+            (typeof ref !== 'object' && options.functions === false)) {         // Only object and function can have properties
+
+            exports.assert(!options.strict || i + 1 === path.length, 'Missing segment', key, 'in reach path ', chain);
+            exports.assert(typeof ref === 'object' || options.functions === true || typeof ref !== 'function', 'Invalid segment', key, 'in reach path ', chain);
+            ref = options.default;
+            break;
+        }
+
+        if (i < path.length - 1) {
+            ref = ref[key];
+        }
+        else {
+            ref = ref[key] = operate(ref[key]);
+        }
+    }
+
+    return ref;
+};
+
 
 exports.reachTemplate = function (obj, template, options) {
 

--- a/test/index.js
+++ b/test/index.js
@@ -1586,6 +1586,123 @@ describe('reach()', () => {
     });
 });
 
+describe('reachTransform()', () => {
+
+    const obj = {
+        a: {
+            b: {
+                c: {
+                    d: 1,
+                    e: 2
+                },
+                f: 'hello'
+            },
+            g: {
+                h: 3
+            }
+        },
+        i: function () { },
+        j: null,
+        k: [4, 8, 9, 1]
+    };
+
+    obj.i.x = 5;
+
+    it('returns object itself', () => {
+
+        expect(Hoek.reachTransform(obj, null, (old) => old)).to.equal(obj);
+        expect(Hoek.reachTransform(obj, false, (old) => old)).to.equal(obj);
+        expect(Hoek.reachTransform(obj, undefined, (old) => old)).to.equal(obj);
+    });
+
+    it('returns first value of array', () => {
+
+        expect(Hoek.reachTransform(obj, 'k.0', (old) => old + 1)).to.equal(5);
+    });
+
+    it('returns last value of array using negative index', () => {
+
+        expect(Hoek.reachTransform(obj, 'k.-2', (old) => old + 1)).to.equal(10);
+    });
+
+    it('returns a valid member', () => {
+
+        expect(Hoek.reachTransform(obj, 'a.b.c.d', (old) => old + 1)).to.equal(2);
+    });
+
+    it('returns a valid member with separator override', () => {
+
+        expect(Hoek.reachTransform(obj, 'a/b/c/d', (old) => old + 1, '/')).to.equal(3);
+    });
+
+    it('returns undefined on null object', () => {
+
+        expect(Hoek.reachTransform(null, 'a.b.c.d', (old) => old + 1)).to.equal(undefined);
+    });
+
+    it('returns undefined on missing object member', () => {
+
+        expect(Hoek.reachTransform(obj, 'a.b.c.d.x', (old) => old + 1)).to.equal(undefined);
+    });
+
+    it('returns undefined on missing function member', () => {
+
+        expect(Hoek.reachTransform(obj, 'i.y', (old) => old + 1, { functions: true })).to.equal(undefined);
+    });
+
+    it('throws on missing member in strict mode', () => {
+
+        expect(() => {
+
+            Hoek.reachTransform(obj, 'a.b.c.o.x', (old) => old + 1, { strict: true });
+        }).to.throw('Missing segment o in reach path  a.b.c.o.x');
+
+    });
+
+    it('returns undefined on invalid member', () => {
+
+        expect(Hoek.reachTransform(obj, 'a.b.c.d-.x', (old) => old + 1)).to.equal(undefined);
+    });
+
+    it('returns function member', () => {
+
+        expect(typeof Hoek.reachTransform(obj, 'i', (old) => old)).to.equal('function');
+    });
+
+    it('returns function property', () => {
+
+        expect(Hoek.reachTransform(obj, 'i.x', (old) => old + 1)).to.equal(6);
+    });
+
+    it('returns null', () => {
+
+        expect(Hoek.reachTransform(obj, 'j', (old) => old)).to.equal(null);
+    });
+
+    it('throws on function property when functions not allowed', () => {
+
+        expect(() => {
+
+            Hoek.reachTransform(obj, 'i.x', (old) => old, { functions: false });
+        }).to.throw('Invalid segment x in reach path  i.x');
+    });
+
+    it('will return a default value if property is not found', () => {
+
+        expect(Hoek.reachTransform(obj, 'a.b.q', (old) => old, { default: 'defaultValue' })).to.equal('defaultValue');
+    });
+
+    it('will return a default value if path is not found', () => {
+
+        expect(Hoek.reachTransform(obj, 'q', (old) => old, { default: 'defaultValue' })).to.equal('defaultValue');
+    });
+
+    it('allows a falsey value to be used as the default value', () => {
+
+        expect(Hoek.reachTransform(obj, 'q', (old) => old, { default: '' })).to.equal('');
+    });
+});
+
 describe('reachTemplate()', () => {
 
     it('applies object to template', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -1585,14 +1585,26 @@ describe('reach()', () => {
         expect(Hoek.reach(obj, 'q', { default: '' })).to.equal('');
     });
 
-    it('transform and returns first value of array', () => {
+    it('transform and returns first value of array after operate', () => {
 
-        expect(Hoek.reach(obj, 'k.0', { operate: (old) => old + 1 })).to.equal(5);
+        expect(Hoek.reach(obj, 'k.0', { operate: (ref, key) => ref[key] + 1 })).to.equal(5);
+        expect(Hoek.reach(obj, 'k.0')).to.equal(4);
+    });
+
+    it('transform and returns first value of array after operate change value', () => {
+
+        expect(Hoek.reach(obj, 'k.0', { operate: (ref, key) => {
+
+            ref[key] += 1;
+            return ref[key];
+        } })).to.equal(5);
+        expect(Hoek.reach(obj, 'k.0')).to.equal(5);
     });
 
     it('returns last value of array using negative index', () => {
 
-        expect(Hoek.reach(obj, 'k.-2', { operate: 8 })).to.equal(8);
+        expect(Hoek.reach(obj, 'k.-2', { operate: 18 })).to.equal(9);
+        expect(Hoek.reach(obj, 'k.-2')).to.equal(18);
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1584,122 +1584,15 @@ describe('reach()', () => {
 
         expect(Hoek.reach(obj, 'q', { default: '' })).to.equal('');
     });
-});
 
-describe('reachTransform()', () => {
+    it('transform and returns first value of array', () => {
 
-    const obj = {
-        a: {
-            b: {
-                c: {
-                    d: 1,
-                    e: 2
-                },
-                f: 'hello'
-            },
-            g: {
-                h: 3
-            }
-        },
-        i: function () { },
-        j: null,
-        k: [4, 8, 9, 1]
-    };
-
-    obj.i.x = 5;
-
-    it('returns object itself', () => {
-
-        expect(Hoek.reachTransform(obj, null, (old) => old)).to.equal(obj);
-        expect(Hoek.reachTransform(obj, false, (old) => old)).to.equal(obj);
-        expect(Hoek.reachTransform(obj, undefined, (old) => old)).to.equal(obj);
-    });
-
-    it('returns first value of array', () => {
-
-        expect(Hoek.reachTransform(obj, 'k.0', (old) => old + 1)).to.equal(5);
+        expect(Hoek.reach(obj, 'k.0', { operate: (old) => old + 1 })).to.equal(5);
     });
 
     it('returns last value of array using negative index', () => {
 
-        expect(Hoek.reachTransform(obj, 'k.-2', (old) => old + 1)).to.equal(10);
-    });
-
-    it('returns a valid member', () => {
-
-        expect(Hoek.reachTransform(obj, 'a.b.c.d', (old) => old + 1)).to.equal(2);
-    });
-
-    it('returns a valid member with separator override', () => {
-
-        expect(Hoek.reachTransform(obj, 'a/b/c/d', (old) => old + 1, '/')).to.equal(3);
-    });
-
-    it('returns undefined on null object', () => {
-
-        expect(Hoek.reachTransform(null, 'a.b.c.d', (old) => old + 1)).to.equal(undefined);
-    });
-
-    it('returns undefined on missing object member', () => {
-
-        expect(Hoek.reachTransform(obj, 'a.b.c.d.x', (old) => old + 1)).to.equal(undefined);
-    });
-
-    it('returns undefined on missing function member', () => {
-
-        expect(Hoek.reachTransform(obj, 'i.y', (old) => old + 1, { functions: true })).to.equal(undefined);
-    });
-
-    it('throws on missing member in strict mode', () => {
-
-        expect(() => {
-
-            Hoek.reachTransform(obj, 'a.b.c.o.x', (old) => old + 1, { strict: true });
-        }).to.throw('Missing segment o in reach path  a.b.c.o.x');
-
-    });
-
-    it('returns undefined on invalid member', () => {
-
-        expect(Hoek.reachTransform(obj, 'a.b.c.d-.x', (old) => old + 1)).to.equal(undefined);
-    });
-
-    it('returns function member', () => {
-
-        expect(typeof Hoek.reachTransform(obj, 'i', (old) => old)).to.equal('function');
-    });
-
-    it('returns function property', () => {
-
-        expect(Hoek.reachTransform(obj, 'i.x', (old) => old + 1)).to.equal(6);
-    });
-
-    it('returns null', () => {
-
-        expect(Hoek.reachTransform(obj, 'j', (old) => old)).to.equal(null);
-    });
-
-    it('throws on function property when functions not allowed', () => {
-
-        expect(() => {
-
-            Hoek.reachTransform(obj, 'i.x', (old) => old, { functions: false });
-        }).to.throw('Invalid segment x in reach path  i.x');
-    });
-
-    it('will return a default value if property is not found', () => {
-
-        expect(Hoek.reachTransform(obj, 'a.b.q', (old) => old, { default: 'defaultValue' })).to.equal('defaultValue');
-    });
-
-    it('will return a default value if path is not found', () => {
-
-        expect(Hoek.reachTransform(obj, 'q', (old) => old, { default: 'defaultValue' })).to.equal('defaultValue');
-    });
-
-    it('allows a falsey value to be used as the default value', () => {
-
-        expect(Hoek.reachTransform(obj, 'q', (old) => old, { default: '' })).to.equal('');
+        expect(Hoek.reach(obj, 'k.-2', { operate: 8 })).to.equal(8);
     });
 });
 


### PR DESCRIPTION
use case:
`
const schema = Joi.object({
  from: Joi.date().required(),
  to: Joi.date().min(Joi.ref('from', { operate: (ref, key) => ref[key] + 3600 })).required()
});
`