### PR TITLE
Update API.md: add wait and block

### DIFF
--- a/API.md
+++ b/API.md
@@ -530,7 +530,7 @@ var result = Hoek.isInteger('23')
 ## Promises
 
 ### wait(timeout)
-Resolve the promise after `timeout` milliseconds.
+Resolve the promise after `timeout`. Provide the `timeout` in milliseconds.
 
 ```javascript
 await Hoek.wait(2000); // waits for 2 seconds

--- a/API.md
+++ b/API.md
@@ -38,6 +38,9 @@
 * [Miscellaneous](#miscellaneous "Miscellaneous")
   * [uniqueFilename](#uniquefilenamepath-extension "uniqueFilename")
   * [isInteger](#isintegervalue "isInteger")
+* [Promises](#promises "Promises")
+  * [wait](#waittimeout "wait")
+  * [block](#block "block")
 
 
 
@@ -517,12 +520,21 @@ Returns a randomly generated file name at the specified `path`. The result is a 
 var result = Hoek.uniqueFilename('./test/modules', 'txt'); // results in "full/path/test/modules/{random}.txt"
 ```
 
-
 ### isInteger(value)
-
 Check `value` to see if it is an integer.  Returns true/false.
 
 ```javascript
 var result = Hoek.isInteger('23')
 ```
 
+## Promises
+
+### wait(timeout)
+Resolve the promise after `timeout` milliseconds.
+
+```javascript
+await Hoek.wait(2000); // waits for 2 seconds
+```
+
+### block()
+A no-op Promise. Does nothing.


### PR DESCRIPTION
This PR adds documentation for the `wait` and `block` methods to `API.md`