### PR TITLE
Added an asyncForEach loop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -232,6 +232,22 @@ internals.reachSet = function (obj, key, value) {
 };
 
 
+exports.asyncForEach = async function (array, iteratingFunction, limit = null) {
+
+    let index = 0;
+    limit = limit && limit <= array.length ? limit : array.length;
+
+    while (index < limit) {
+        const shouldIterateFurther = await iteratingFunction(array[index], index, array);
+        if (shouldIterateFurther === false) {
+            break;
+        }
+        index++;
+    }
+
+    return array;
+};
+
 // Apply options to defaults except for the listed keys which are shallow copied from option without merging
 
 exports.applyToDefaultsWithShallow = function (defaults, options, keys) {

--- a/test/index.js
+++ b/test/index.js
@@ -2407,3 +2407,59 @@ describe('block()', () => {
         Hoek.ignore = orig;
     });
 });
+
+describe('asyncForEach()', () => {
+
+    it('iterates over array from start to end', async () => {
+
+        const originalArray = [1,2,3,4,5];
+        await Hoek.asyncForEach(originalArray, (num, index, array) => {
+
+            array[index] = num + num;
+        });
+
+        expect(originalArray).to.equal([2,4,6,8,10]);
+    });
+
+    it('iterates over only 1st 3 elements of array of size 5', async () => {
+
+        const originalArray = [1,2,3,4,5];
+        await Hoek.asyncForEach(originalArray, (num, index, array) => {
+
+            array[index] = num + num;
+        }, 3);
+
+        expect(originalArray).to.equal([2,4,6,4,5]);
+    });
+
+    it('break when false is found', async () => {
+
+        const originalArray = [1,2,3,4,5];
+        await Hoek.asyncForEach(originalArray, (num, index, array) => {
+
+            array[index] = num * 10;
+            if (num % 3 === 0) {
+                return false;
+            }
+        });
+
+        expect(originalArray).to.equal([10,20,30,4,5]);
+    });
+
+    it('copies elements in an array to another', async () => {
+
+        const originalArray = [1,2,3,4,5];
+        const newArray = [];
+
+        expect(originalArray).to.equal([1,2,3,4,5]);
+        expect(newArray).to.equal([]);
+
+        await Hoek.asyncForEach(originalArray, (num) => {
+
+            newArray.push(num);
+        });
+
+        expect(originalArray).to.equal([1,2,3,4,5]);
+        expect(newArray).to.equal([1,2,3,4,5]);
+    });
+});


### PR DESCRIPTION
Closes #271 

This `asyncForEach` function works like `forEach` function of `lodash`.  
Since hoek is a utility library, a `forEach` function which could work asynchronously was necessary.  
Even lodash doesn't have a `forEach` that could run asynchronously. And doesn't go well with an `async` iteratee function too.

This `asyncForEach` function is capable of taking an `async` iteratee function. 