### PR TITLE
Fix contain() with duplicates and only

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -372,10 +372,17 @@ exports.contain = function (ref, values, options) {
         misses = !!leftovers;
     }
     else if (Array.isArray(ref)) {
+        const onlyOnce = !!(options.only && options.once);
+        if (onlyOnce && ref.length !== values.length) {
+            return false;
+        }
+
         for (let i = 0; i < ref.length; ++i) {
             let matched = false;
             for (let j = 0; j < values.length && matched === false; ++j) {
-                matched = compare(values[j], ref[i], compareFlags) && j;
+                if (!onlyOnce || matches[j] === 0) {
+                    matched = compare(values[j], ref[i], compareFlags) && j;
+                }
             }
 
             if (matched !== false) {
@@ -406,6 +413,12 @@ exports.contain = function (ref, values, options) {
         }
     }
 
+    if (options.only) {
+        if (misses || !options.once) {
+            return !misses;
+        }
+    }
+
     let result = false;
     for (let i = 0; i < matches.length; ++i) {
         result = result || !!matches[i];
@@ -414,12 +427,6 @@ exports.contain = function (ref, values, options) {
 
             return false;
         }
-    }
-
-    if (options.only &&
-        misses) {
-
-        return false;
     }
 
     return result;

--- a/test/index.js
+++ b/test/index.js
@@ -1518,6 +1518,9 @@ describe('contain()', () => {
         expect(Hoek.contain([1, 2], [1, 2], { once: true })).to.be.true();
         expect(Hoek.contain([1, 2, 3], [1, 4], { part: true })).to.be.true();
         expect(Hoek.contain([[1], [2]], [[1]], { deep: true })).to.be.true();
+        expect(Hoek.contain([1, 2, 1], [1, 1, 2], { only: true })).to.be.true();
+        expect(Hoek.contain([1, 2, 1], [1, 1, 2], { only: true, once: true })).to.be.true();
+        expect(Hoek.contain([1, 2, 1], [1, 2, 2], { only: true })).to.be.true();
 
         expect(Hoek.contain([1, 2, 3], 4)).to.be.false();
         expect(Hoek.contain([{ a: 1 }], { a: 2 }, { deep: true })).to.be.false();
@@ -1529,6 +1532,8 @@ describe('contain()', () => {
         expect(Hoek.contain([1, 3, 2], [1, 2], { only: true })).to.be.false();
         expect(Hoek.contain([1, 2, 2], [1, 2], { once: true })).to.be.false();
         expect(Hoek.contain([0, 2, 3], [1, 4], { part: true })).to.be.false();
+        expect(Hoek.contain([1, 2, 1], [1, 2, 2], { only: true, once: true })).to.be.false();
+        expect(Hoek.contain([1, 2, 1], [1, 2], { only: true, once: true })).to.be.false();
     });
 
     it('tests objects', () => {


### PR DESCRIPTION
The `only: true` option concerns unlisted values. It doesn't add any meaning to multiple listings of the same value.

I have added some extra meaning when combined with `once: true`, where each entry is consumed once it has been found.