### PR TITLE
Update stringify docs to reflect arg spreading

### DIFF
--- a/API.md
+++ b/API.md
@@ -276,7 +276,7 @@ var obj = {a : {b : { c : 1}}};
 Hoek.reachTemplate(obj, '1+{a.b.c}=2'); // returns '1+1=2'
 ```
 
-#### stringify(obj)
+#### stringify(...args)
 
 Converts an object to string using the built-in `JSON.stringify()` method with the difference that any errors are caught
 and reported back in the form of the returned string. Used as a shortcut for displaying information to the console (e.g. in


### PR DESCRIPTION
Noticed that the docs for `Hoek.stringify` implied that only an object was allowed to be passed, but the code uses argument spreading which allows for passing of things like `obj, null, 4` for formatting purposes. 