### PR TITLE
Handle promises in deepEqual()

### DIFF
--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -12,6 +12,7 @@ const internals = {
     errorType: Symbol('error'),
     genericType: Symbol('generic'),
     mapType: Symbol('map'),
+    promiseType: Symbol('promise'),
     regexType: Symbol('regex'),
     setType: Symbol('set'),
     weakMapType: Symbol('weak-map'),
@@ -25,6 +26,7 @@ internals.typeMap = {
     '[object Date]': internals.dateType,
     '[object Error]': internals.errorType,
     '[object Map]': internals.mapType,
+    '[object Promise]': internals.promiseType,
     '[object RegExp]': internals.regexType,
     '[object Set]': internals.setType,
     '[object WeakMap]': internals.weakMapType,
@@ -285,6 +287,8 @@ internals.isDeepEqual = function (obj, ref, options, seen) {
     switch (instanceType) {
         case internals.bufferType:
             return Buffer.prototype.equals.call(obj, ref);
+        case internals.promiseType:
+            return obj === ref;
         case internals.regexType:
             return obj.toString() === ref.toString();
         case internals.mismatched:

--- a/test/index.js
+++ b/test/index.js
@@ -1274,6 +1274,14 @@ describe('deepEqual()', () => {
         expect(Hoek.deepEqual(maps[0], new Map())).to.be.false();
     });
 
+    it('compares promises', () => {
+
+        const a = new Promise(() => {});
+
+        expect(Hoek.deepEqual(a, a)).to.be.true();
+        expect(Hoek.deepEqual(a, new Promise(() => { }))).to.be.false();
+    });
+
     it('compares buffers', () => {
 
         expect(Hoek.deepEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3]))).to.be.true();


### PR DESCRIPTION
This extends `deepEqual()` to handle the native `Promise` type by doing a simple reference comparison.

This fixes the current behaviour, where  comparing promises essentially compares `{}` to `{}`, which always passes.

@hueniverse Promise comparisons need to be released before I can properly finalize the Promise support in #248.