### PR TITLE
Clone Map and Set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,24 +53,16 @@ exports.clone = function (obj, options = {}, _seen = null) {
         }
         else if (obj instanceof Set) {
             newObj = new Set();
+            cloneDeep = true;
             for (const val of obj) {
-                if (typeof val === 'object') {
-                    newObj.add(exports.clone(val));
-                    cloneDeep = true;
-                }
-                else {
-                    newObj.add(val);
-                }
+                newObj.add(exports.clone(val));
             }
         }
         else if (obj instanceof Map) {
             newObj = new Map();
+            cloneDeep = true;
             for (let [key, value] of obj) {
-                if (typeof value === 'object') {
-                    value = exports.clone(value);
-                    cloneDeep = true;
-                }
-
+                value = exports.clone(value);
                 newObj.set(key, value);
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,19 @@ const internals = {};
 exports.deepEqual = DeepEqual;
 
 
+internals.clonePromise = async (promise) => {
+
+    try {
+        var res = await promise;
+    }
+    catch (err) {
+        throw exports.clone(err);
+    }
+
+    return exports.clone(res);
+};
+
+
 // Clone object or array
 
 exports.clone = function (obj, options = {}, _seen = null) {
@@ -67,7 +80,8 @@ exports.clone = function (obj, options = {}, _seen = null) {
             }
         }
         else if (obj instanceof Promise) {
-            newObj = obj.then((success) => exports.clone(success), (err) => exports.clone(err));
+            newObj = internals.clonePromise(obj);
+            cloneDeep = true;
         }
         else {
             if (options.prototype !== false) {          // Defaults to true

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,12 @@ exports.clone = function (obj, options = {}, _seen = null) {
                 }
             }
         }
+        else if (obj instanceof Promise) {
+            newObj = obj.then(
+                (success) => (success),
+                (err) => (err)
+            );
+        }
         else {
             if (options.prototype !== false) {          // Defaults to true
                 const proto = Object.getPrototypeOf(obj);

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,19 +20,6 @@ const internals = {};
 exports.deepEqual = DeepEqual;
 
 
-internals.clonePromise = async (promise) => {
-
-    try {
-        var res = await promise;
-    }
-    catch (err) {
-        throw exports.clone(err);
-    }
-
-    return exports.clone(res);
-};
-
-
 // Clone object or array
 
 exports.clone = function (obj, options = {}, _seen = null) {
@@ -78,10 +65,6 @@ exports.clone = function (obj, options = {}, _seen = null) {
                 value = exports.clone(value);
                 newObj.set(key, value);
             }
-        }
-        else if (obj instanceof Promise) {
-            newObj = internals.clonePromise(obj);
-            cloneDeep = true;
         }
         else {
             if (options.prototype !== false) {          // Defaults to true

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,13 +53,13 @@ exports.clone = function (obj, options = {}, _seen = null) {
         }
         else if (obj instanceof Set) {
             newObj = new Set();
-            const vals = Array.from(obj);
-            for (let i = 0; i < vals.length; ++i) {
-                if (typeof vals[i] === 'object') {
-                    newObj.add(exports.clone(vals[i]));
+            for (const val of obj) {
+                if (typeof val === 'object') {
+                    newObj.add(exports.clone(val));
+                    cloneDeep = true;
                 }
                 else {
-                    newObj.add(vals[i]);
+                    newObj.add(val);
                 }
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,18 @@ exports.clone = function (obj, options = {}, _seen = null) {
         else if (obj instanceof RegExp) {
             newObj = new RegExp(obj);
         }
+        else if (obj instanceof Set) {
+            newObj = new Set();
+            const vals = Array.from(obj);
+            for (let i = 0; i < vals.length; ++i) {
+                if (typeof vals[i] === 'object') {
+                    newObj.add(exports.clone(vals[i]));
+                }
+                else {
+                    newObj.add(vals[i]);
+                }
+            }
+        }
         else {
             if (options.prototype !== false) {          // Defaults to true
                 const proto = Object.getPrototypeOf(obj);

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,11 +65,10 @@ exports.clone = function (obj, options = {}, _seen = null) {
         }
         else if (obj instanceof Map) {
             newObj = new Map();
-            const entries = Array.from(obj);
-            for (let i = 0; i < entries.length; ++i) {
-                let [key, value] = entries[i];
+            for (let [key, value] of obj) {
                 if (typeof value === 'object') {
                     value = exports.clone(value);
+                    cloneDeep = true;
                 }
                 newObj.set(key, value);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,10 +64,7 @@ exports.clone = function (obj, options = {}, _seen = null) {
             }
         }
         else if (obj instanceof Promise) {
-            newObj = obj.then(
-                (success) => (success),
-                (err) => (err)
-            );
+            newObj = obj.then();
         }
         else {
             if (options.prototype !== false) {          // Defaults to true

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ exports.clone = function (obj, options = {}, _seen = null) {
             }
         }
         else if (obj instanceof Promise) {
-            newObj = obj.then();
+            newObj = obj.then((success) => exports.clone(success), (err) => exports.clone(err));
         }
         else {
             if (options.prototype !== false) {          // Defaults to true

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,7 @@ exports.clone = function (obj, options = {}, _seen = null) {
                     value = exports.clone(value);
                     cloneDeep = true;
                 }
+
                 newObj.set(key, value);
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,17 @@ exports.clone = function (obj, options = {}, _seen = null) {
                 }
             }
         }
+        else if (obj instanceof Map) {
+            newObj = new Map();
+            const entries = Array.from(obj);
+            for (let i = 0; i < entries.length; ++i) {
+                let [key, value] = entries[i];
+                if (typeof value === 'object') {
+                    value = exports.clone(value);
+                }
+                newObj.set(key, value);
+            }
+        }
         else if (obj instanceof Promise) {
             newObj = obj.then();
         }

--- a/test/index.js
+++ b/test/index.js
@@ -504,7 +504,45 @@ describe('clone()', () => {
             });
         });
     });
+
+    it('clones Maps', () => {
+
+        const a = new Map();
+        a.set('a', 1);
+        a.set('b', 2);
+        a.set('c', 3);
+
+        const b = Hoek.clone(a);
+
+        expect(a).to.equal(b);
+    });
+
+    it('clones Maps containing objects as values (no pass by reference)', () => {
+
+        const a = new Map();
+        a.set('a', 1);
+        a.set('b', 2);
+        a.set('c', nestedObj);
+
+        const b = Hoek.clone(a);
+        const result = a.get('c') === b.get('c');
+        expect(result).to.equal(false);
+    });
+
+    it('clones Maps containing objects as keys (are passed by reference)', () => {
+
+        const a = new Map();
+        a.set('a', 1);
+        a.set('b', 2);
+        a.set(nestedObj, 3);
+
+        const b = Hoek.clone(a);
+        const result = a.get(nestedObj) === b.get(nestedObj);
+        expect(result).to.equal(true);
+    });
 });
+
+
 
 describe('merge()', () => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -546,8 +546,6 @@ describe('clone()', () => {
     });
 });
 
-
-
 describe('merge()', () => {
 
     it('deep copies source items', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -431,6 +431,25 @@ describe('clone()', () => {
         const copy = Hoek.clone(obj);
         expect(copy).to.equal(obj);
     });
+
+    it('clones sets', () => {
+
+        const a = new Set([1, 2, 3]);
+
+        const b = Hoek.clone(a);
+
+        expect(a).to.equal(b);
+    });
+
+    it('clones sets containing objects (no pass by reference)', () => {
+
+        const a = new Set([1, 2, 3]);
+        a.add(nestedObj);
+
+        const b = Hoek.clone(a);
+
+        expect(b.has(nestedObj)).to.equal(false);
+    });
 });
 
 describe('merge()', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -438,7 +438,8 @@ describe('clone()', () => {
 
         const b = Hoek.clone(a);
 
-        expect(a).to.equal(b);
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
     });
 
     it('clones sets containing objects (no pass by reference)', () => {
@@ -448,7 +449,8 @@ describe('clone()', () => {
 
         const b = Hoek.clone(a);
 
-        expect(b.has(nestedObj)).to.equal(false);
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
     });
 
     it('clones Promises', () => {
@@ -514,7 +516,7 @@ describe('clone()', () => {
 
         const b = Hoek.clone(a);
 
-        expect(a).to.equal(b);
+        expect(b).to.not.shallow.equal(new Map([['a', 1], ['b', 2], ['c', 3]]));
     });
 
     it('clones Maps containing objects as values (no pass by reference)', () => {
@@ -525,8 +527,9 @@ describe('clone()', () => {
         a.set('c', nestedObj);
 
         const b = Hoek.clone(a);
-        const result = a.get('c') === b.get('c');
-        expect(result).to.equal(false);
+
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
     });
 
     it('clones Maps containing objects as keys (are passed by reference)', () => {
@@ -537,8 +540,9 @@ describe('clone()', () => {
         a.set(nestedObj, 3);
 
         const b = Hoek.clone(a);
-        const result = a.get(nestedObj) === b.get(nestedObj);
-        expect(result).to.equal(true);
+
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -450,6 +450,18 @@ describe('clone()', () => {
 
         expect(b.has(nestedObj)).to.equal(false);
     });
+
+    it('clones Promises', () => {
+
+        const a = new Promise((resolve, reject) => {
+
+            setTimeout(resolve, 0);
+        });
+
+        const b = Hoek.clone(a);
+
+        expect(a).to.equal(b);
+    });
 });
 
 describe('merge()', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -473,62 +473,6 @@ describe('clone()', () => {
         expect(b.has(nestedObj)).to.be.false(a);
     });
 
-    it('clones a Promise', () => {
-
-        const a = Promise.resolve();
-        const b = Hoek.clone(a);
-
-        expect(b).to.equal(a);
-        expect(b).to.not.equal(Promise.resolve());
-        expect(b).to.not.shallow.equal(a);
-    });
-
-    it('clones an implicit Promise from async', () => {
-
-        const a = (async () => true)();
-        const b = Hoek.clone(a);
-
-        expect(b).to.equal(a);
-        expect(b).to.not.equal((async () => true)());
-        expect(b).to.not.shallow.equal(a);
-    });
-
-    it('clones properties set on a Promise', () => {
-
-        const a = Promise.resolve();
-        a.val = { b: 2 };
-
-        const b = Hoek.clone(a);
-
-        expect(b).to.equal(a);
-        expect(b.val).to.equal(a.val);
-        expect(b.val).to.not.shallow.equal(a.val);
-    });
-
-    it('clone objects resolved by a Promise (no pass by reference)', async () => {
-
-        const a = Promise.resolve({ a: 1, b: 2 });
-        const b = Hoek.clone(a);
-
-        const res1 = await a;
-        const res2 = await b;
-
-        expect(res2).to.equal(res1);
-        expect(res2).to.not.shallow.equal(res1);
-    });
-
-    it('clone objects rejects by a Promise (no pass by reference)', async () => {
-
-        const a = Promise.reject({ a: 1, b: 2 });
-        const b = Hoek.clone(a);
-
-        const err1 = await expect(a).to.reject();
-        const err2 = await expect(b).to.reject();
-
-        expect(err2).to.equal(err1);
-        expect(err2).to.not.shallow.equal(err1);
-    });
-
     it('clones a Map', () => {
 
         const a = new Map([['a', 1], ['b', 2], ['c', 3]]);

--- a/test/index.js
+++ b/test/index.js
@@ -465,7 +465,7 @@ describe('clone()', () => {
         expect(a).to.equal(b);
     });
 
-    it('cloned Promises should resolve like original promise', () => {
+    it('clone objects resolved by the function (no pass by reference)', () => {
 
         const a = new Promise((resolve, reject) => {
 
@@ -481,12 +481,12 @@ describe('clone()', () => {
             b.then((successTwo) => {
 
                 expect(successOne).to.equal(successTwo);
-                expect(successOne === successTwo).to.equal(true);
+                expect(successOne === successTwo).to.equal(false);
             });
         });
     });
 
-    it('cloned Promises should reject like original promise', () => {
+    it('clone objects rejects by the function (no pass by reference)', () => {
 
         const a = new Promise((resolve, reject) => {
 
@@ -502,7 +502,7 @@ describe('clone()', () => {
             b.catch((errTwo) => {
 
                 expect(errOne).to.equal(errTwo);
-                expect(errOne === errTwo).to.equal(true);
+                expect(errOne === errTwo).to.equal(false);
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -462,6 +462,48 @@ describe('clone()', () => {
 
         expect(a).to.equal(b);
     });
+
+    it('cloned Promises should resolve like original promise', () => {
+
+        const a = new Promise((resolve, reject) => {
+
+            setTimeout(() => {
+
+                resolve({ 'a':1, 'b':2 });
+            }, 0);
+        });
+
+        const b = Hoek.clone(a);
+        a.then((successOne) => {
+
+            b.then((successTwo) => {
+
+                expect(successOne).to.equal(successTwo);
+                expect(successOne === successTwo).to.equal(true);
+            });
+        });
+    });
+
+    it('cloned Promises should reject like original promise', () => {
+
+        const a = new Promise((resolve, reject) => {
+
+            setTimeout(() => {
+
+                reject({ 'a':1, 'b':2 });
+            }, 0);
+        });
+
+        const b = Hoek.clone(a);
+        a.catch((errOne) => {
+
+            b.catch((errTwo) => {
+
+                expect(errOne).to.equal(errTwo);
+                expect(errOne === errTwo).to.equal(true);
+            });
+        });
+    });
 });
 
 describe('merge()', () => {


### PR DESCRIPTION
This is a continuation of #248, containing expanded and revised tests.

I decided to remove the `Promise` cloning altogether after some thought. The reason is that, with node native promises, it is impossible to do a clone without potentially changing the behavior of the source `Promise`. More specifically, attaching a `catch` handler means that it can no longer trigger an `unhandledRejection` process error.