### PR TITLE
Fix clone of subclassed Set and Map

### DIFF
--- a/lib/deep-equal.js
+++ b/lib/deep-equal.js
@@ -2,35 +2,13 @@
 
 // Load modules
 
+const Types = require('./types');
+
 
 // Declare internals
 
 const internals = {
-    arrayType: Symbol('array'),
-    bufferType: Symbol('buffer'),
-    dateType: Symbol('date'),
-    errorType: Symbol('error'),
-    genericType: Symbol('generic'),
-    mapType: Symbol('map'),
-    promiseType: Symbol('promise'),
-    regexType: Symbol('regex'),
-    setType: Symbol('set'),
-    weakMapType: Symbol('weak-map'),
-    weakSetType: Symbol('weak-set'),
-    mismatched: Symbol('mismatched')
-};
-
-
-internals.typeMap = {
-    '[object Array]': internals.arrayType,
-    '[object Date]': internals.dateType,
-    '[object Error]': internals.errorType,
-    '[object Map]': internals.mapType,
-    '[object Promise]': internals.promiseType,
-    '[object RegExp]': internals.regexType,
-    '[object Set]': internals.setType,
-    '[object WeakMap]': internals.weakMapType,
-    '[object WeakSet]': internals.weakSetType
+    mismatched: null
 };
 
 
@@ -63,11 +41,11 @@ internals.isDeepEqual = function (obj, ref, options, seen) {
 
     const instanceType = internals.getSharedType(obj, ref, !!options.prototype);
     switch (instanceType) {
-        case internals.bufferType:
+        case Types.buffer:
             return Buffer.prototype.equals.call(obj, ref);
-        case internals.promiseType:
+        case Types.promise:
             return obj === ref;
-        case internals.regexType:
+        case Types.regex:
             return obj.toString() === ref.toString();
         case internals.mismatched:
             return false;
@@ -90,19 +68,6 @@ internals.isDeepEqual = function (obj, ref, options, seen) {
 };
 
 
-internals.getInternalType = function (obj) {
-
-    const { typeMap, bufferType, genericType } = internals;
-
-    if (obj instanceof Buffer) {
-        return bufferType;
-    }
-
-    const objName = Object.prototype.toString.call(obj);
-    return typeMap[objName] || genericType;
-};
-
-
 internals.getSharedType = function (obj, ref, checkPrototype) {
 
     if (checkPrototype) {
@@ -110,11 +75,11 @@ internals.getSharedType = function (obj, ref, checkPrototype) {
             return internals.mismatched;
         }
 
-        return internals.getInternalType(obj);
+        return Types.getInternalProto(obj);
     }
 
-    const type = internals.getInternalType(obj);
-    if (type !== internals.getInternalType(ref)) {
+    const type = Types.getInternalProto(obj);
+    if (type !== Types.getInternalProto(ref)) {
         return internals.mismatched;
     }
 
@@ -161,7 +126,7 @@ internals.isDeepEqualObj = function (instanceType, obj, ref, options, seen) {
     const { isDeepEqual, valueOf, hasOwnEnumerableProperty } = internals;
     const { keys, getOwnPropertySymbols } = Object;
 
-    if (instanceType === internals.arrayType) {
+    if (instanceType === Types.array) {
         if (options.part) {
             // Check if any index match any other index
 
@@ -188,7 +153,7 @@ internals.isDeepEqualObj = function (instanceType, obj, ref, options, seen) {
             return true;
         }
     }
-    else if (instanceType === internals.setType) {
+    else if (instanceType === Types.set) {
         if (obj.size !== ref.size) {
             return false;
         }
@@ -218,7 +183,7 @@ internals.isDeepEqualObj = function (instanceType, obj, ref, options, seen) {
             }
         }
     }
-    else if (instanceType === internals.mapType) {
+    else if (instanceType === Types.map) {
         if (obj.size !== ref.size) {
             return false;
         }
@@ -233,7 +198,7 @@ internals.isDeepEqualObj = function (instanceType, obj, ref, options, seen) {
             }
         }
     }
-    else if (instanceType === internals.errorType) {
+    else if (instanceType === Types.error) {
         // Always check name and message
 
         if (obj.name !== ref.name || obj.message !== ref.message) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,11 +8,14 @@ const Path = require('path');
 
 const DeepEqual = require('./deep-equal');
 const Escape = require('./escape');
+const Types = require('./types');
 
 
 // Declare internals
 
-const internals = {};
+const internals = {
+    needsProtoHack: new Set([Types.set, Types.map, Types.weakSet, Types.weakMap])
+};
 
 
 // Deep object or array comparison
@@ -37,92 +40,90 @@ exports.clone = function (obj, options = {}, _seen = null) {
         return lookup;
     }
 
+    const baseProto = Types.getInternalProto(obj);
     let newObj;
-    let cloneDeep = false;
-    const isArray = Array.isArray(obj);
 
-    if (!isArray) {
-        if (Buffer.isBuffer(obj)) {
-            newObj = Buffer.from(obj);
-        }
-        else if (obj instanceof Date) {
-            newObj = new Date(obj.getTime());
-        }
-        else if (obj instanceof RegExp) {
-            newObj = new RegExp(obj);
-        }
-        else if (obj instanceof Set) {
-            newObj = new Set();
-            seen.set(obj, newObj);
-            cloneDeep = true;
-            for (const val of obj) {
-                newObj.add(exports.clone(val, options, seen));
-            }
-        }
-        else if (obj instanceof Map) {
-            newObj = new Map();
-            seen.set(obj, newObj);
-            cloneDeep = true;
-            for (let [key, val] of obj) {
-                val = exports.clone(val, options, seen);
-                newObj.set(key, val);
-            }
-        }
-        else {
-            if (options.prototype !== false) {          // Defaults to true
+    switch (baseProto) {
+        case Types.buffer:
+            return Buffer.from(obj);
+
+        case Types.date:
+            return new Date(obj.getTime());
+
+        case Types.regex:
+            return new RegExp(obj);
+
+        case Types.array:
+            newObj = [];
+            break;
+
+        default:
+            if (options.prototype !== false) {              // Defaults to true
                 const proto = Object.getPrototypeOf(obj);
                 if (proto &&
                     proto.isImmutable) {
 
-                    newObj = obj;
+                    return obj;
+                }
+
+                if (internals.needsProtoHack.has(baseProto)) {
+                    newObj = new proto.constructor();
+                    if (proto !== baseProto) {
+                        Object.setPrototypeOf(newObj, proto);
+                    }
                 }
                 else {
                     newObj = Object.create(proto);
-                    cloneDeep = true;
                 }
+            }
+            else if (internals.needsProtoHack.has(baseProto)) {
+                newObj = new baseProto.constructor();
             }
             else {
                 newObj = {};
-                cloneDeep = true;
             }
-        }
-    }
-    else {
-        newObj = [];
-        cloneDeep = true;
     }
 
-    seen.set(obj, newObj);
+    seen.set(obj, newObj);                                  // Set seen, since obj could recurse
 
-    if (cloneDeep) {
-        const keys = internals.keys(obj, options);
-        for (let i = 0; i < keys.length; ++i) {
-            const key = keys[i];
+    if (baseProto === Types.set) {
+        for (const value of obj) {
+            newObj.add(exports.clone(value, options, seen));
+        }
+    }
+    else if (baseProto === Types.map) {
+        for (const [key, value] of obj) {
+            newObj.set(key, exports.clone(value, options, seen));
+        }
+    }
 
-            if (isArray && key === 'length') {
-                continue;
-            }
+    const keys = internals.keys(obj, options);
+    for (let i = 0; i < keys.length; ++i) {
+        const key = keys[i];
 
-            const descriptor = Object.getOwnPropertyDescriptor(obj, key);
-            if (descriptor &&
-                (descriptor.get ||
-                    descriptor.set)) {
-
-                Object.defineProperty(newObj, key, descriptor);
-            }
-            else {
-                Object.defineProperty(newObj, key, {
-                    enumerable: descriptor ? descriptor.enumerable : true,
-                    writable: true,
-                    configurable: true,
-                    value: exports.clone(obj[key], options, seen)
-                });
-            }
+        if (baseProto === Types.array && key === 'length') {
+            continue;
         }
 
-        if (isArray) {
-            newObj.length = obj.length;
+        const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+        if (descriptor &&
+            (descriptor.get ||
+                descriptor.set)) {
+
+            Object.defineProperty(newObj, key, descriptor);
         }
+        else {
+            Object.defineProperty(newObj, key, {
+                enumerable: descriptor ? descriptor.enumerable : true,
+                writable: true,
+                configurable: true,
+                value: exports.clone(obj[key], options, seen)
+            });
+        }
+    }
+
+    if (baseProto === Types.array) {
+        newObj.length = obj.length;
     }
 
     return newObj;

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const internals = {};
+
+
+exports = module.exports = {
+    array: Array.prototype,
+    buffer: Buffer.prototype,
+    date: Date.prototype,
+    error: Error.prototype,
+    generic: Object.prototype,
+    map: Map.prototype,
+    promise: Promise.prototype,
+    regex: RegExp.prototype,
+    set: Set.prototype,
+    weakMap: WeakMap.prototype,
+    weakSet: WeakSet.prototype
+};
+
+
+internals.typeMap = new Map([
+    ['[object Array]', exports.array],
+    ['[object Date]', exports.date],
+    ['[object Error]', exports.error],
+    ['[object Map]', exports.map],
+    ['[object Promise]', exports.promise],
+    ['[object RegExp]', exports.regex],
+    ['[object Set]', exports.set],
+    ['[object WeakMap]', exports.weakMap],
+    ['[object WeakSet]', exports.weakSet]
+]);
+
+
+exports.getInternalProto = function (obj) {
+
+    const { typeMap } = internals;
+    const { buffer, generic } = exports;
+
+    if (obj instanceof Buffer) {
+        return buffer;
+    }
+
+    const objName = Object.prototype.toString.call(obj);
+    return typeMap.get(objName) || generic;
+};

--- a/test/index.js
+++ b/test/index.js
@@ -516,6 +516,24 @@ describe('clone()', () => {
         expect(b.val).to.not.shallow.equal(a.val);
     });
 
+    it('clones subclassed Set', () => {
+
+        const MySet = class extends Set { };
+
+        const a = new MySet([1]);
+        const b = Hoek.clone(a);
+
+        expect(b).to.equal(a);
+        expect(b).to.be.instanceof(MySet);
+
+        const c = Hoek.clone(a, { prototype: false });
+
+        expect(c).to.not.equal(a, { prototype: true });
+        expect(c).to.equal(a, { prototype: false });
+        expect(c).to.be.instanceof(Set);
+        expect(c).to.not.be.instanceof(MySet);
+    });
+
     it('clones Set containing objects (no pass by reference)', () => {
 
         const a = new Set([1, 2, 3]);
@@ -555,6 +573,24 @@ describe('clone()', () => {
         expect(b).to.equal(a);
         expect(b.val).to.equal(a.val);
         expect(b.val).to.not.shallow.equal(a.val);
+    });
+
+    it('clones subclassed Map', () => {
+
+        const MyMap = class extends Map {};
+
+        const a = new MyMap([['a', 1]]);
+        const b = Hoek.clone(a);
+
+        expect(b).to.equal(a);
+        expect(b).to.be.instanceof(MyMap);
+
+        const c = Hoek.clone(a, { prototype: false });
+
+        expect(c).to.not.equal(a, { prototype: true });
+        expect(c).to.equal(a, { prototype: false });
+        expect(c).to.be.instanceof(Map);
+        expect(c).to.not.be.instanceof(MyMap);
     });
 
     it('clones Map containing objects as values (no pass by reference)', () => {


### PR DESCRIPTION
I just wanted to fix the harmless double `seen.set()` for `Set` and `Map` clones introduced in #301, but found a new bug: _`Hoek.clone()` does not transfer the prototype of a subclassed `Set` or `Map`_.

I did a fix for this, but found that objects created using `Object.create(proto)` are broken. Instead I ended up at this, where I create a base object, and change its prototype (if required).

There is a lot of changes here, but most is refactoring to make a somewhat clean and performant implementation.