### PR TITLE
Fix empty ref bug in contain when only is true

### DIFF
--- a/lib/contain.js
+++ b/lib/contain.js
@@ -59,7 +59,11 @@ module.exports = function (ref, values, options = {}) {        // options: { dee
     }
 
     if (typeof ref === 'string') {
-        if (!ref.length) {
+        if (ref === '') {
+            if (values.length === 1 && values[0] === '') {
+                return true;
+            }
+
             return false;
         }
 

--- a/lib/contain.js
+++ b/lib/contain.js
@@ -59,6 +59,10 @@ module.exports = function (ref, values, options = {}) {        // options: { dee
     }
 
     if (typeof ref === 'string') {
+        if (!ref.length) {
+            return false;
+        }
+
         let pattern = '(';
         for (let i = 0; i < values.length; ++i) {
             const value = values[i];
@@ -77,6 +81,10 @@ module.exports = function (ref, values, options = {}) {        // options: { dee
         misses = !!leftovers;
     }
     else if (Array.isArray(ref)) {
+        if (!ref.length) {
+            return false;
+        }
+
         const onlyOnce = !!(options.only && options.once);
         if (onlyOnce && ref.length !== values.length) {
             return false;
@@ -100,6 +108,10 @@ module.exports = function (ref, values, options = {}) {        // options: { dee
     }
     else {
         const keys = Utils.keys(ref, options);
+        if (!keys.length) {
+            return false;
+        }
+
         for (let i = 0; i < keys.length; ++i) {
             const key = keys[i];
             const pos = values.indexOf(key);

--- a/lib/contain.js
+++ b/lib/contain.js
@@ -60,8 +60,10 @@ module.exports = function (ref, values, options = {}) {        // options: { dee
 
     if (typeof ref === 'string') {
         if (ref === '') {
-            if (values.length === 1 && values[0] === '') {
-                return true;
+            if (values.join('') === '') {
+                if (values.length === 1 || options.only || options.part) {
+                    return true;
+                }
             }
 
             return false;

--- a/lib/contain.js
+++ b/lib/contain.js
@@ -61,7 +61,7 @@ module.exports = function (ref, values, options = {}) {        // options: { dee
     if (typeof ref === 'string') {
         if (ref === '') {
             if (values.join('') === '') {
-                if (values.length === 1 || options.only || options.part) {
+                if (values.length === 1 || !options.once) {
                     return true;
                 }
             }

--- a/test/index.js
+++ b/test/index.js
@@ -2094,6 +2094,8 @@ describe('contain()', () => {
 
         expect(Hoek.contain('', 'a')).to.be.false();
         expect(Hoek.contain('', 'a', { only: true })).to.be.false();
+        
+        expect(Hoek.contain('', '')).to.be.true()
     });
 
     it('tests arrays', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2094,8 +2094,13 @@ describe('contain()', () => {
 
         expect(Hoek.contain('', 'a')).to.be.false();
         expect(Hoek.contain('', 'a', { only: true })).to.be.false();
-        
-        expect(Hoek.contain('', '')).to.be.true()
+
+        expect(Hoek.contain('', '')).to.be.true();
+        expect(Hoek.contain('', ''), { only: true }).to.be.true();
+        expect(Hoek.contain('', ''), { once: true }).to.be.true();
+        expect(Hoek.contain('', ['', ''])).to.be.true();
+        expect(Hoek.contain('', ['', ''], { only: true })).to.be.true();
+        expect(Hoek.contain('', ['', ''], { once: true })).to.be.false();
     });
 
     it('tests arrays', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2091,6 +2091,9 @@ describe('contain()', () => {
         expect(Hoek.contain('abb', 'b', { once: true })).to.be.false();
         expect(Hoek.contain('abc', ['a', 'd'])).to.be.false();
         expect(Hoek.contain('abc', ['ab', 'bc'])).to.be.false();                      // Overlapping values not supported
+
+        expect(Hoek.contain('', 'a')).to.be.false();
+        expect(Hoek.contain('', 'a', { only: true })).to.be.false();
     });
 
     it('tests arrays', () => {
@@ -2121,6 +2124,9 @@ describe('contain()', () => {
         expect(Hoek.contain([0, 2, 3], [1, 4], { part: true })).to.be.false();
         expect(Hoek.contain([1, 2, 1], [1, 2, 2], { only: true, once: true })).to.be.false();
         expect(Hoek.contain([1, 2, 1], [1, 2], { only: true, once: true })).to.be.false();
+
+        expect(Hoek.contain([], 1)).to.be.false();
+        expect(Hoek.contain([], 1, { only: true })).to.be.false();
     });
 
     it('tests objects', () => {
@@ -2156,6 +2162,9 @@ describe('contain()', () => {
         expect(Hoek.contain({ a: { b: { c: 1, d: 2 } } }, { a: { b: { c: 1 } } }, { deep: true, part: true })).to.be.true();
         expect(Hoek.contain({ a: { b: { c: 1, d: 2 } } }, { a: { b: { c: 1 } } }, { deep: true, part: false })).to.be.false();
         expect(Hoek.contain({ a: [1, 2, 3] }, { a: [4, 5, 6] }, { deep: true, part: true })).to.be.false();
+
+        expect(Hoek.contain({}, 'a')).to.be.false();
+        expect(Hoek.contain({}, 'a', { only: true })).to.be.false();
 
         // Getter check
         {


### PR DESCRIPTION
This fixes #323.

I added in some special logic for strings so that `contain('', '')` is still true and `contain('', ['', ''])` is true with any combo of flags as long as `options.once` is false. The latter is a change to the current behavior (`contain('', ['', ''])` is currently false), but I believe the current behavior there is also a bug.