### PR TITLE
Safer and faster shallow handling

### DIFF
--- a/lib/applyToDefaults.js
+++ b/lib/applyToDefaults.js
@@ -3,7 +3,7 @@
 const Assert = require('./assert');
 const Clone = require('./clone');
 const Merge = require('./merge');
-const Utils = require('./utils');
+const Reach = require('./reach');
 
 
 const internals = {};
@@ -42,14 +42,55 @@ internals.applyToDefaultsWithShallow = function (defaults, source, options) {
     options = Object.assign({}, options);
     options.shallow = false;
 
-    const copy = Clone(defaults, { shallow: keys });
+    const seen = new Map();
+    const merge = source === true ? null : new Set();
 
-    if (source === true) {                                                      // If source is set to true, use defaults
+    for (let key of keys) {
+        key = Array.isArray(key) ? key : key.split('.');            // Pre-split optimization
+
+        const ref = Reach(defaults, key);
+        if (ref && typeof ref === 'object') {
+            seen.set(ref, merge ? Reach(source, key) : ref);
+        }
+        else if (merge) {
+            merge.add(key);
+        }
+    }
+
+    const copy = Clone(defaults, {}, seen);
+
+    if (!merge) {
         return copy;
     }
 
-    const storage = Utils.store(source, keys);                              // Move shallow copy items to storage
-    Merge(copy, source, { mergeArrays: false, nullOverride: false });   // Deep copy the rest
-    Utils.restore(copy, source, storage);                                   // Shallow copy the stored items and restore
-    return copy;
+    for (const key of merge) {
+        internals.reachCopy(copy, source, key);
+    }
+
+    return Merge(copy, source, { mergeArrays: false, nullOverride: false });
+};
+
+
+internals.reachCopy = function (dst, src, path) {
+
+    for (const segment of path) {
+        if (!(segment in src)) {
+            return;
+        }
+
+        src = src[segment];
+    }
+
+    const value = src;
+    let ref = dst;
+    for (let i = 0; i < path.length - 1; ++i) {
+        const segment = path[i];
+        if (typeof ref[segment] !== 'object') {
+            ref[segment] = {};
+        }
+
+        ref = ref[segment];
+    }
+
+    ref[path[path.length - 1]] = value;
 };

--- a/lib/applyToDefaults.js
+++ b/lib/applyToDefaults.js
@@ -39,9 +39,6 @@ internals.applyToDefaultsWithShallow = function (defaults, source, options) {
     const keys = options.shallow;
     Assert(Array.isArray(keys), 'Invalid keys');
 
-    options = Object.assign({}, options);
-    options.shallow = false;
-
     const seen = new Map();
     const merge = source === true ? null : new Set();
 

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Reach = require('./reach');
 const Types = require('./types');
 const Utils = require('./utils');
 
@@ -135,8 +136,16 @@ internals.cloneWithShallow = function (source, options) {
     options = Object.assign({}, options);
     options.shallow = false;
 
-    const storage = Utils.store(source, keys);    // Move shallow copy items to storage
-    const copy = internals.clone(source, options);      // Deep copy the rest
-    Utils.restore(copy, source, storage);         // Shallow copy the stored items and restore
-    return copy;
+    const seen = new Map();
+
+    for (const key of keys) {
+        const ref = Reach(source, key);
+        if (typeof ref === 'object' ||
+            typeof ref === 'function') {
+
+            seen.set(ref, ref);
+        }
+    }
+
+    return internals.clone(source, options, seen);
 };

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -45,6 +45,10 @@ module.exports = internals.merge = function (target, source, options) {
         if (value &&
             typeof value === 'object') {
 
+            if (target[key] === value) {
+                continue;                                           // Can occur for shallow merges
+            }
+
             if (!target[key] ||
                 typeof target[key] !== 'object' ||
                 (Array.isArray(target[key]) !== Array.isArray(value)) ||

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,54 +1,9 @@
 'use strict';
 
-const Reach = require('./reach');
-
-
 const internals = {};
 
 
 exports.keys = function (obj, options = {}) {
 
     return options.symbols !== false ? Reflect.ownKeys(obj) : Object.getOwnPropertyNames(obj);  // Defaults to true
-};
-
-
-exports.store = function (source, keys) {
-
-    const storage = new Map();
-    for (let i = 0; i < keys.length; ++i) {
-        const key = keys[i];
-        const value = Reach(source, key);
-        if (typeof value === 'object' ||
-            typeof value === 'function') {
-
-            storage.set(key, value);
-            internals.reachSet(source, key, undefined);
-        }
-    }
-
-    return storage;
-};
-
-
-exports.restore = function (copy, source, storage) {
-
-    for (const [key, value] of storage) {
-        internals.reachSet(copy, key, value);
-        internals.reachSet(source, key, value);
-    }
-};
-
-
-internals.reachSet = function (obj, key, value) {
-
-    const path = Array.isArray(key) ? key : key.split('.');
-    let ref = obj;
-    for (let i = 0; i < path.length; ++i) {
-        const segment = path[i];
-        if (i + 1 === path.length) {
-            ref[segment] = value;
-        }
-
-        ref = ref[segment];
-    }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -762,6 +762,19 @@ describe('clone()', () => {
         expect(copy.a).to.shallow.equal(obj.a);
         expect(copy.x).to.shallow.equal(obj);
     });
+
+    it('does not invoke setter when shallow cloning', () => {
+
+        const obj = {};
+
+        Object.defineProperty(obj, 'a', { enumerable: true, value: {} });
+        Object.defineProperty(obj, 'b', { enumerable: true, value: {} });
+
+        const copy = Hoek.clone(obj, { shallow: ['a'] });
+
+        expect(copy).equal({ a: {}, b: {} });
+        expect(copy.a).to.shallow.equal(obj.a);
+    });
 });
 
 describe('merge()', () => {
@@ -1498,6 +1511,24 @@ describe('applyToDefaults()', () => {
         const merged = Hoek.applyToDefaults(defaults, options, { shallow: [['c', sym]] });
         expect(merged).to.equal({ a: { b: 4, e: 3 }, c: { d: 6, [sym]: { g: 1 } } });
         expect(merged.c[sym]).to.shallow.equal(options.c[sym]);
+    });
+
+    it('does not modify shallow entries in source', () => {
+
+        const defaults = {
+            a: {
+                b: 5
+            }
+        };
+
+        const source = {};
+
+        Object.defineProperty(source, 'a', { value: { b: 4 } });
+
+        const merged = Hoek.applyToDefaults(defaults, source, { shallow: ['a'] });
+        expect(merged).to.equal({ a: { b: 4 } });
+        expect(merged.a).to.equal(source.a);
+        expect(merged.a).to.not.equal(defaults.a);
     });
 });
 


### PR DESCRIPTION
This patch refactors the shallow handling of `clone()` and `applyToDefaults()` to avoid temporarily modifying the source object, and setting properties on the target object multiple times.

The handling is done in a simple and effective manner by pre-filling a `seen` `Map()` that is passed to the internal call to `clone()`.

This new handling should also increase the performance of shallow copies.