### PR TITLE
Fix 'compare is not a function'

### DIFF
--- a/lib/contain.js
+++ b/lib/contain.js
@@ -108,6 +108,8 @@ internals.array = function (ref, values, options) {
             match = map.get(item);
         }
         else {
+            compare = compare || internals.compare(options);
+            
             for (const [key, existing] of map.entries()) {
                 if (compare(key, item)) {
                     match = existing;


### PR DESCRIPTION
Fix issue with lab test trying to use compare(...) function out of scope.

Ex: 

Failed tests:

      compare is not a function

      at Object.internals.array (~/Source/.../node_modules/@hapi/hoek/lib/contain.js:113:21)
      at Object.module.exports [as contain] (~/Source/.../node_modules/@hapi/hoek/lib/contain.js:36:26)
      at internals.Assertion.internals.include (~/Source/.../node_modules/@hapi/code/lib/index.js:212:29)
      at test (~/Source/.../server/test/company-matchmaking-companies-api.js:119:27)
      at process.internalTickCallback (internal/process/next_tick.js:77:7)