### PR TITLE
Add returnValue option to wait()

### DIFF
--- a/API.md
+++ b/API.md
@@ -384,11 +384,12 @@ A simple no-op function. It does nothing at all.
 
 ### Promises
 
-#### wait(timeout)
-Resolve the promise after `timeout`. Provide the `timeout` in milliseconds.
+#### wait(timeout, [returnValue])
+Resolve the promise after `timeout` milliseconds with the provided `returnValue`.
 
 ```javascript
 await Hoek.wait(2000); // waits for 2 seconds
+const timeout = Hoek.wait(1000, 'timeout'); // resolves after 1s with 'timeout'
 ```
 
 #### block()

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -433,10 +433,11 @@ export function stringify(value: any, replacer?: any, space?: string | number): 
  * Returns a Promise that resolves after the requested timeout.
  *
  * @param timeout - The number of milliseconds to wait before resolving the Promise.
+ * @param returnValue - The value that the Promise will resolve to.
  *
- * @return A Promise.
+ * @return A Promise that resolves with `returnValue`.
  */
-export function wait(timeout?: number): Promise<void>;
+export function wait<T>(timeout?: number, returnValue?: T): Promise<T>;
 
 
 /**

--- a/lib/wait.js
+++ b/lib/wait.js
@@ -3,7 +3,11 @@
 const internals = {};
 
 
-module.exports = function (timeout) {
+module.exports = function (timeout, returnValue) {
 
-    return new Promise((resolve) => setTimeout(resolve, timeout));
+    if (typeof timeout !== 'number' && timeout !== undefined) {
+        throw new TypeError('Timeout must be a number');
+    }
+
+    return new Promise((resolve) => setTimeout(resolve, timeout, returnValue));
 };

--- a/test/index.ts
+++ b/test/index.ts
@@ -305,6 +305,7 @@ await Hoek.wait(123);
 
 expect.type<Promise<void>>(Hoek.wait());
 expect.type<void>(await Hoek.wait(100));
+expect.type<Promise<string>>(Hoek.wait(100, 'ok'));
 
 expect.error(Hoek.wait({}));
 // $lab:types:on$


### PR DESCRIPTION
The new block() test can be simplified by adding a returnValue to `Hoek.wait()`, so I did an implementation.

I also added some proper tests for wait(), and changed it to only support numbers or `undefined` for the timeout option. This means that it now throws, if eg. an object is passed.