### PR TITLE
Always call base class methods to inspect Map and Set

### DIFF
--- a/lib/deepEqual.js
+++ b/lib/deepEqual.js
@@ -119,8 +119,8 @@ internals.hasOwnEnumerableProperty = function (obj, key) {
 
 internals.isSetSimpleEqual = function (obj, ref) {
 
-    for (const entry of obj) {
-        if (!ref.has(entry)) {
+    for (const entry of Set.prototype.values.call(obj)) {
+        if (!Set.prototype.has.call(ref, entry)) {
             return false;
         }
     }
@@ -170,8 +170,8 @@ internals.isDeepEqualObj = function (instanceType, obj, ref, options, seen) {
 
             // Check for deep equality
 
-            const ref2 = new Set(ref);
-            for (const objEntry of obj) {
+            const ref2 = new Set(Set.prototype.values.call(ref));
+            for (const objEntry of Set.prototype.values.call(obj)) {
                 if (ref2.delete(objEntry)) {
                     continue;
                 }
@@ -196,12 +196,12 @@ internals.isDeepEqualObj = function (instanceType, obj, ref, options, seen) {
             return false;
         }
 
-        for (const [key, value] of obj) {
-            if (value === undefined && !ref.has(key)) {
+        for (const [key, value] of Map.prototype.entries.call(obj)) {
+            if (value === undefined && !Map.prototype.has.call(ref, key)) {
                 return false;
             }
 
-            if (!isDeepEqual(value, ref.get(key), options, seen)) {
+            if (!isDeepEqual(value, Map.prototype.get.call(ref, key), options, seen)) {
                 return false;
             }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -948,6 +948,49 @@ describe('deepEqual()', () => {
         expect(Hoek.deepEqual(sets[0], new Set())).to.be.false();
     });
 
+    it('compares extended sets', () => {
+
+        class PrivateSet extends Set {
+
+            has() {
+
+                throw new Error('not allowed');
+            }
+        }
+
+        const entries = ['a', undefined];
+        expect(Hoek.deepEqual(new PrivateSet(), new PrivateSet())).to.be.true();
+        expect(Hoek.deepEqual(new PrivateSet(entries), new PrivateSet(entries))).to.be.true();
+        expect(Hoek.deepEqual(new PrivateSet(entries), new Set(entries), { prototype: false })).to.be.true();
+        expect(Hoek.deepEqual(new PrivateSet(entries), new Set(entries), { prototype: true })).to.be.false();
+        expect(Hoek.deepEqual(new PrivateSet(), new PrivateSet(entries))).to.be.false();
+        expect(Hoek.deepEqual(new PrivateSet(entries), new PrivateSet())).to.be.false();
+
+        class LockableSet extends Set {
+
+            constructor(values, locked = true) {
+
+                super(values);
+                this.locked = locked;
+            }
+
+            has() {
+
+                if (this.locked) {
+                    throw new Error('not allowed');
+                }
+            }
+        }
+
+        expect(Hoek.deepEqual(new LockableSet(), new LockableSet())).to.be.true();
+        expect(Hoek.deepEqual(new LockableSet(entries), new LockableSet(entries))).to.be.true();
+        expect(Hoek.deepEqual(new LockableSet(entries, false), new LockableSet(entries, false))).to.be.true();
+        expect(Hoek.deepEqual(new LockableSet(entries, true), new LockableSet(entries, false))).to.be.false();
+        expect(Hoek.deepEqual(new LockableSet(entries, false), new LockableSet(entries, true))).to.be.false();
+        expect(Hoek.deepEqual(new LockableSet(entries), new Set(entries), { prototype: false })).to.be.false();
+        expect(Hoek.deepEqual(new LockableSet(entries), new PrivateSet(entries), { prototype: false })).to.be.false();
+    });
+
     it('compares maps', () => {
 
         const item1 = { key: 'value1' };
@@ -972,6 +1015,49 @@ describe('deepEqual()', () => {
         });
         expect(Hoek.deepEqual(maps[0], maps[1])).to.be.true();
         expect(Hoek.deepEqual(maps[0], new Map())).to.be.false();
+    });
+
+    it('compares extended maps', () => {
+
+        class PrivateMap extends Map {
+
+            get() {
+
+                throw new Error('not allowed');
+            }
+        }
+
+        const entries = [['a', 1], ['b', undefined]];
+        expect(Hoek.deepEqual(new PrivateMap(), new PrivateMap())).to.be.true();
+        expect(Hoek.deepEqual(new PrivateMap(entries), new PrivateMap(entries))).to.be.true();
+        expect(Hoek.deepEqual(new PrivateMap(entries), new Map(entries), { prototype: false })).to.be.true();
+        expect(Hoek.deepEqual(new PrivateMap(entries), new Map(entries), { prototype: true })).to.be.false();
+        expect(Hoek.deepEqual(new PrivateMap(), new PrivateMap(entries))).to.be.false();
+        expect(Hoek.deepEqual(new PrivateMap(entries), new PrivateMap())).to.be.false();
+
+        class LockableMap extends Map {
+
+            constructor(kvs, locked = true) {
+
+                super(kvs);
+                this.locked = locked;
+            }
+
+            get() {
+
+                if (this.locked) {
+                    throw new Error('not allowed');
+                }
+            }
+        }
+
+        expect(Hoek.deepEqual(new LockableMap(), new LockableMap())).to.be.true();
+        expect(Hoek.deepEqual(new LockableMap(entries), new LockableMap(entries))).to.be.true();
+        expect(Hoek.deepEqual(new LockableMap(entries, false), new LockableMap(entries, false))).to.be.true();
+        expect(Hoek.deepEqual(new LockableMap(entries, true), new LockableMap(entries, false))).to.be.false();
+        expect(Hoek.deepEqual(new LockableMap(entries, false), new LockableMap(entries, true))).to.be.false();
+        expect(Hoek.deepEqual(new LockableMap(entries), new Map(entries), { prototype: false })).to.be.false();
+        expect(Hoek.deepEqual(new LockableMap(entries), new PrivateMap(entries), { prototype: false })).to.be.false();
     });
 
     it('compares promises', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2220,25 +2220,21 @@ describe('wait()', () => {
 
     it('delays for timeout ms', async () => {
 
-        // DO NOT USE Hoek.Bench() to time this, as its test depends on Hoek.wait()
-
-        const start = process.hrtime.bigint();
+        let timeout = false;
+        setTimeout(() => (timeout = true), 10);
         await Hoek.wait(10);
-        const end = process.hrtime.bigint();
 
-        expect(end - start).to.be.between(10_000_000, 20_000_000);
+        expect(timeout).to.be.true();
     });
 
     it('handles a return value', async () => {
 
-        // DO NOT USE Hoek.Bench() to time this, as its test depends on Hoek.wait()
-
         const uniqueValue = {};
-        const start = process.hrtime.bigint();
+        let timeout = false;
+        setTimeout(() => (timeout = true), 10);
         const returnValue = await Hoek.wait(10, uniqueValue);
-        const end = process.hrtime.bigint();
 
-        expect(end - start).to.be.between(10_000_000, 20_000_000);
+        expect(timeout).to.be.true();
         expect(returnValue).to.shallow.equal(uniqueValue);
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -2220,22 +2220,28 @@ describe('wait()', () => {
 
     it('delays for timeout ms', async () => {
 
-        let timeout = false;
-        setTimeout(() => (timeout = true), 10);
-        await Hoek.wait(10);
+        const timeout = {};
+        setTimeout(() => (timeout.before = true), 10);
+        const wait = Hoek.wait(10);
+        setTimeout(() => (timeout.after = true), 10);
 
-        expect(timeout).to.be.true();
+        await wait;
+
+        expect(timeout.before).to.be.true();
+        expect(timeout.after).to.be.undefined();
     });
 
     it('handles a return value', async () => {
 
         const uniqueValue = {};
-        let timeout = false;
-        setTimeout(() => (timeout = true), 10);
-        const returnValue = await Hoek.wait(10, uniqueValue);
+        const timeout = {};
+        setTimeout(() => (timeout.before = true), 10);
+        const wait = Hoek.wait(10, uniqueValue);
+        setTimeout(() => (timeout.after = true), 10);
 
-        expect(timeout).to.be.true();
-        expect(returnValue).to.shallow.equal(uniqueValue);
+        expect(await wait).to.shallow.equal(uniqueValue);
+        expect(timeout.before).to.be.true();
+        expect(timeout.after).to.be.undefined();
     });
 
     it('undefined timeout resolves immediately', async () => {


### PR DESCRIPTION
Closes #357, and handles additional cases with `has()`, and overridden iterators.