### PR TITLE
Fix applyToDefaults to work better with non-object source values

### DIFF
--- a/lib/applyToDefaults.js
+++ b/lib/applyToDefaults.js
@@ -79,7 +79,7 @@ internals.reachCopy = function (dst, src, path) {
 
         const val = src[segment];
 
-        if (val === null || val === undefined) {
+        if (typeof val !== 'object' || val === null) {
             return;
         }
 

--- a/lib/applyToDefaults.js
+++ b/lib/applyToDefaults.js
@@ -73,7 +73,7 @@ internals.applyToDefaultsWithShallow = function (defaults, source, options) {
 internals.reachCopy = function (dst, src, path) {
 
     for (const segment of path) {
-        if (!(segment in src)) {
+        if (src[segment] === undefined) {
             return;
         }
 

--- a/lib/applyToDefaults.js
+++ b/lib/applyToDefaults.js
@@ -73,11 +73,13 @@ internals.applyToDefaultsWithShallow = function (defaults, source, options) {
 internals.reachCopy = function (dst, src, path) {
 
     for (const segment of path) {
-        if (src[segment] === undefined) {
+        const val = src[segment];
+
+        if (val === null || val === undefined) {
             return;
         }
 
-        src = src[segment];
+        src = val;
     }
 
     const value = src;

--- a/lib/applyToDefaults.js
+++ b/lib/applyToDefaults.js
@@ -73,6 +73,10 @@ internals.applyToDefaultsWithShallow = function (defaults, source, options) {
 internals.reachCopy = function (dst, src, path) {
 
     for (const segment of path) {
+        if (!(segment in src)) {
+            return;
+        }
+
         const val = src[segment];
 
         if (val === null || val === undefined) {

--- a/test/index.js
+++ b/test/index.js
@@ -639,24 +639,54 @@ describe('applyToDefaults()', () => {
         expect(merged).to.equal({ a: { b: 4 }, c: { g: { r: { h: 8 } } } });
     });
 
-    it('shallow copies the nested keys (null/undefined)', () => {
+    it('shallow copies the nested keys (falsy)', () => {
 
         const defaults = {
-            a: {
-                y: 1
+            _undefined: {
+                a: 1
             },
-            b: {
-                y: 2
+            _null: {
+                a: 2
+            },
+            _false: {
+                a: 3
+            },
+            _emptyString: {
+                a: 4
+            },
+            _zero: {
+                a: 5
+            },
+            _NaN: {
+                a: 6
             }
         };
 
         const source = {
-            a: undefined,
-            b: null
+            _undefined: undefined,
+            _null: null,
+            _false: false,
+            _emptyString: '',
+            _zero: 0,
+            _NaN: NaN
         };
 
-        const merged = Hoek.applyToDefaults(defaults, source, { shallow: ['a.y', 'b.y'] });
-        expect(merged).to.equal({ a: { y: 1 }, b: { y: 2 } });
+        const merged = Hoek.applyToDefaults(defaults, source, { shallow: [
+            '_undefined.a',
+            '_null.a',
+            '_false.a',
+            '_emptyString.a',
+            '_zero.a',
+            '_NaN.a'
+        ] });
+        expect(merged).to.equal({
+            _undefined: { a: 1 },
+            _null: { a: 2 },
+            _false: false,
+            _emptyString: '',
+            _zero: 0,
+            _NaN: NaN
+        });
     });
 
     it('shallow copies the listed keys in the defaults', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -639,20 +639,24 @@ describe('applyToDefaults()', () => {
         expect(merged).to.equal({ a: { b: 4 }, c: { g: { r: { h: 8 } } } });
     });
 
-    it('shallow copies the nested keys (undefined)', () => {
+    it('shallow copies the nested keys (null/undefined)', () => {
 
         const defaults = {
             a: {
-                b: 1
+                y: 1
+            },
+            b: {
+                y: 2
             }
         };
 
         const source = {
-            a: undefined
+            a: undefined,
+            b: null
         };
 
-        const merged = Hoek.applyToDefaults(defaults, source, { shallow: ['a.b'] });
-        expect(merged).to.equal({ a: { b: 1 } });
+        const merged = Hoek.applyToDefaults(defaults, source, { shallow: ['a.y', 'b.y'] });
+        expect(merged).to.equal({ a: { y: 1 }, b: { y: 2 } });
     });
 
     it('shallow copies the listed keys in the defaults', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -639,9 +639,10 @@ describe('applyToDefaults()', () => {
         expect(merged).to.equal({ a: { b: 4 }, c: { g: { r: { h: 8 } } } });
     });
 
-    it('shallow copies the nested keys (falsy)', () => {
+    it('shallow copies the nested keys (non-object)', () => {
 
         const defaults = {
+            // All falsy values:
             _undefined: {
                 a: 1
             },
@@ -659,6 +660,19 @@ describe('applyToDefaults()', () => {
             },
             _NaN: {
                 a: 6
+            },
+            // Other non-object values:
+            _string: {
+                a: 7
+            },
+            _number: {
+                a: 8
+            },
+            _true: {
+                a: 9
+            },
+            _function: {
+                a: 10
             }
         };
 
@@ -668,7 +682,11 @@ describe('applyToDefaults()', () => {
             _false: false,
             _emptyString: '',
             _zero: 0,
-            _NaN: NaN
+            _NaN: NaN,
+            _string: 'foo',
+            _number: 42,
+            _true: true,
+            _function: () => {}
         };
 
         const merged = Hoek.applyToDefaults(defaults, source, { shallow: [
@@ -677,7 +695,11 @@ describe('applyToDefaults()', () => {
             '_false.a',
             '_emptyString.a',
             '_zero.a',
-            '_NaN.a'
+            '_NaN.a',
+            '_string.a',
+            '_number.a',
+            '_true.a',
+            '_function.a'
         ] });
         expect(merged).to.equal({
             _undefined: { a: 1 },
@@ -685,7 +707,11 @@ describe('applyToDefaults()', () => {
             _false: false,
             _emptyString: '',
             _zero: 0,
-            _NaN: NaN
+            _NaN: NaN,
+            _string: 'foo',
+            _number: 42,
+            _true: true,
+            _function: source._function
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -639,6 +639,22 @@ describe('applyToDefaults()', () => {
         expect(merged).to.equal({ a: { b: 4 }, c: { g: { r: { h: 8 } } } });
     });
 
+    it('shallow copies the nested keys (undefined)', () => {
+
+        const defaults = {
+            a: {
+                b: 1
+            }
+        };
+
+        const source = {
+            a: undefined
+        };
+
+        const merged = Hoek.applyToDefaults(defaults, source, { shallow: ['a.b'] });
+        expect(merged).to.equal({ a: { b: 1 } });
+    });
+
     it('shallow copies the listed keys in the defaults', () => {
 
         const defaults = {


### PR DESCRIPTION
Without this change the test would throw the following exception:

```
Cannot use 'in' operator to search for 'b' in undefined

at Object.internals.reachCopy (/Users/watson/code/node_modules/@hapi/hoek/lib/applyToDefaults.js:76:23)
at Object.internals.applyToDefaultsWithShallow (/Users/watson/code/node_modules/@hapi/hoek/lib/applyToDefaults.js:66:19)
at Object.module.exports [as applyToDefaults] (/Users/watson/code/node_modules/@hapi/hoek/lib/applyToDefaults.js:23:26)
at /Users/watson/code/node_modules/@hapi/hoek/test/index.js:654:29
at Immediate.<anonymous> (/Users/watson/code/node_modules/@hapi/hoek/node_modules/@hapi/lab/lib/runner.js:661:35)
at processImmediate (internal/timers.js:461:21)
```

I discovered this issue when registering a route in hapi like so:

```js
server.route({
  method: 'GET',
  path: '/',
  handler: () => 'ok',
  options: {
    validate: undefined
  }
})
```

The fact that `validate` is `undefined` will make this call to `route` throw.