### PR TITLE
applyToDefaults: respect nullOverride when shallow is used

### DIFF
--- a/lib/applyToDefaults.js
+++ b/lib/applyToDefaults.js
@@ -66,7 +66,8 @@ internals.applyToDefaultsWithShallow = function (defaults, source, options) {
         internals.reachCopy(copy, source, key);
     }
 
-    return Merge(copy, source, { mergeArrays: false, nullOverride: false });
+    const nullOverride = options.nullOverride !== undefined ? options.nullOverride : false;
+    return Merge(copy, source, { nullOverride, mergeArrays: false });
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -846,6 +846,16 @@ describe('applyToDefaults()', () => {
         expect(merged.a).to.shallow.equal(source.a);
         expect(merged.a).to.not.equal(defaults.a);
     });
+
+    it('should respect nullOverride when shallow is used', () => {
+
+        const defaults = { host: 'localhost', port: 8000 };
+        const source = { host: null, port: 8080 };
+
+        const result = Hoek.applyToDefaults(defaults, source, { nullOverride: true, shallow: [] });
+        expect(result.host).to.equal(null);
+        expect(result.port).to.equal(8080);
+    });
 });
 
 describe('deepEqual()', () => {


### PR DESCRIPTION
Fixes #366