### PR TITLE
Support named imports when using node esm loader

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,29 +1,45 @@
 'use strict';
 
-const internals = {};
+exports.applyToDefaults = require('./applyToDefaults');
 
+exports.assert = require('./assert');
 
-module.exports = {
-    applyToDefaults: require('./applyToDefaults'),
-    assert: require('./assert'),
-    Bench: require('./bench'),
-    block: require('./block'),
-    clone: require('./clone'),
-    contain: require('./contain'),
-    deepEqual: require('./deepEqual'),
-    Error: require('./error'),
-    escapeHeaderAttribute: require('./escapeHeaderAttribute'),
-    escapeHtml: require('./escapeHtml'),
-    escapeJson: require('./escapeJson'),
-    escapeRegex: require('./escapeRegex'),
-    flatten: require('./flatten'),
-    ignore: require('./ignore'),
-    intersect: require('./intersect'),
-    isPromise: require('./isPromise'),
-    merge: require('./merge'),
-    once: require('./once'),
-    reach: require('./reach'),
-    reachTemplate: require('./reachTemplate'),
-    stringify: require('./stringify'),
-    wait: require('./wait')
-};
+exports.Bench = require('./bench');
+
+exports.block = require('./block');
+
+exports.clone = require('./clone');
+
+exports.contain = require('./contain');
+
+exports.deepEqual = require('./deepEqual');
+
+exports.Error = require('./error');
+
+exports.escapeHeaderAttribute = require('./escapeHeaderAttribute');
+
+exports.escapeHtml = require('./escapeHtml');
+
+exports.escapeJson = require('./escapeJson');
+
+exports.escapeRegex = require('./escapeRegex');
+
+exports.flatten = require('./flatten');
+
+exports.ignore = require('./ignore');
+
+exports.intersect = require('./intersect');
+
+exports.isPromise = require('./isPromise');
+
+exports.merge = require('./merge');
+
+exports.once = require('./once');
+
+exports.reach = require('./reach');
+
+exports.reachTemplate = require('./reachTemplate');
+
+exports.stringify = require('./stringify');
+
+exports.wait = require('./wait');

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Hoek;
+
+    before(async () => {
+
+        Hoek = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Hoek)).to.equal([
+            'Bench',
+            'Error',
+            'applyToDefaults',
+            'assert',
+            'block',
+            'clone',
+            'contain',
+            'deepEqual',
+            'default',
+            'escapeHeaderAttribute',
+            'escapeHtml',
+            'escapeJson',
+            'escapeRegex',
+            'flatten',
+            'ignore',
+            'intersect',
+            'isPromise',
+            'merge',
+            'once',
+            'reach',
+            'reachTemplate',
+            'stringify',
+            'wait'
+        ]);
+    });
+});


### PR DESCRIPTION
This rewrites the exports for compatibility with [node.js commonjs static analysis](https://nodejs.org/api/esm.html).

With this PR, Hoek methods and classes can be imported, as expected, when using the ESM loader .

I added a new file to test this. I had to make the `import` dynamic since Lab does not currently support ESM.