### PR TITLE
Handle very long timeouts in Hoek.wait()

### DIFF
--- a/lib/wait.js
+++ b/lib/wait.js
@@ -1,13 +1,37 @@
 'use strict';
 
-const internals = {};
+const internals = {
+    maxTimer: 2 ** 31 - 1              // ~25 days
+};
 
 
-module.exports = function (timeout, returnValue) {
+module.exports = function (timeout, returnValue, options) {
 
-    if (typeof timeout !== 'number' && timeout !== undefined) {
-        throw new TypeError('Timeout must be a number');
+    if (typeof timeout === 'bigint') {
+        timeout = Number(timeout);
     }
 
-    return new Promise((resolve) => setTimeout(resolve, timeout, returnValue));
+    if (timeout >= Number.MAX_SAFE_INTEGER) {         // Thousands of years
+        timeout = Infinity;
+    }
+
+    if (typeof timeout !== 'number' && timeout !== undefined) {
+        throw new TypeError('Timeout must be a number or bigint');
+    }
+
+    return new Promise((resolve) => {
+
+        const _setTimeout = options ? options.setTimeout : setTimeout;
+
+        const activate = () => {
+
+            const time = Math.min(timeout, internals.maxTimer);
+            timeout -= time;
+            _setTimeout(() => (timeout > 0 ? activate() : resolve(returnValue)), time);
+        };
+
+        if (timeout !== Infinity) {
+            activate();
+        }
+    });
 };


### PR DESCRIPTION
This enhances `Hoek.wait()` to properly handle timeouts of more than `2^31 - 1` ms.

The existing implementation makes no mention of the fact that it is based on `setTimeout()` and its inherent limitation of `2^31 - 1` ms. As it is right now, any value larger than this (which equates to around 25 days), is treated as if `1` was passed, and triggers a `TimeoutOverflowWarning` from node:

```
(node:99363) TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

While fixing this, I also took the opportunity to support timeout values using `BigInt` numbers, which I think makes sense for a modern API.

Note that the implementation now returns a never resolving `Promise` for *exceptionally long* timeout values (including `Infinity`), making it work similar to `Hoek.block()`.

### Alternatives considered

Update the docs to note the limitation, and immediately throw an error if passed values larger than `2^31 - 1`.

The implementation could also be more accurate for longs waits, but it requires manually tracking elapsed time, which does not seem worth the effort. The API should still wait *at least* the time specified.