### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -11,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v10
       - master
   pull_request:
   workflow_dispatch:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-Copyright (c) 2011-2020, Sideway Inc, and project contributors  
-Copyright (c) 2011-2014, Walmart  
+Copyright (c) 2011-2022, Sideway Inc, and project contributors
+Copyright (c) 2011-2014, Walmart
 Copyright (c) 2011, Yahoo Inc.
 
 All rights reserved.

--- a/lib/contain.js
+++ b/lib/contain.js
@@ -79,7 +79,7 @@ internals.array = function (ref, values, options) {
             }
         }
         else {
-            compare = compare || internals.compare(options);
+            compare = compare ?? internals.compare(options);
 
             let found = false;
             for (const [key, existing] of map.entries()) {
@@ -108,7 +108,7 @@ internals.array = function (ref, values, options) {
             match = map.get(item);
         }
         else {
-            compare = compare || internals.compare(options);
+            compare = compare ?? internals.compare(options);
 
             for (const [key, existing] of map.entries()) {
                 if (compare(key, item)) {

--- a/lib/deepEqual.js
+++ b/lib/deepEqual.js
@@ -271,8 +271,7 @@ internals.isDeepEqualObj = function (instanceType, obj, ref, options, seen) {
         const refSymbols = new Set(getOwnPropertySymbols(ref));
 
         for (const key of objSymbols) {
-            if (!options.skip ||
-                !options.skip.includes(key)) {
+            if (!options.skip?.includes(key)) {
 
                 if (hasOwnEnumerableProperty(obj, key)) {
                     if (!hasOwnEnumerableProperty(ref, key)) {

--- a/lib/isPromise.js
+++ b/lib/isPromise.js
@@ -5,5 +5,5 @@ const internals = {};
 
 module.exports = function (promise) {
 
-    return !!promise && typeof promise.then === 'function';
+    return typeof promise?.then === 'function';
 };

--- a/lib/reachTemplate.js
+++ b/lib/reachTemplate.js
@@ -11,6 +11,6 @@ module.exports = function (obj, template, options) {
     return template.replace(/{([^{}]+)}/g, ($0, chain) => {
 
         const value = Reach(obj, chain, options);
-        return (value === undefined || value === null ? '' : value);
+        return value ?? '';
     });
 };

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
       "plugin:@hapi/module"
     ]
   },
-  "dependencies": {},
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "9.0.0-beta.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "^24.0.0",
-    "typescript": "~4.0.2"
+    "@hapi/lab": "25.0.0-beta.1",
+    "@types/node": "^17.0.30",
+    "typescript": "~4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update typescript and node v18-compatible versions of lab and code.

If this looks good, this will go out as hoek v10.