### PR TITLE
Fix license years for Sideway versus contributors

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2011-2022, Sideway Inc, and project contributors
+Copyright (c) 2011-2022, Project contributors
+Copyright (c) 2011-2020, Sideway Inc
 Copyright (c) 2011-2014, Walmart
 Copyright (c) 2011, Yahoo Inc.
 


### PR DESCRIPTION
Fixing a change made in #377 to ensure the Sideway license years remain accurate.