### PR TITLE
Fix version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     ]
   },
   "devDependencies": {
-    "@hapi/code": "9.0.0-beta.0",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "25.0.0-beta.1",
+    "@hapi/lab": "^25.0.1",
     "@types/node": "^17.0.30",
     "typescript": "~4.6.4"
   },


### PR DESCRIPTION
Currently fixed beta versions of `lab` and `code` are used. They should have probably have been specified with a caret `^`.