### PR TITLE
fix: expose AssertError

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,7 +6,7 @@
  *
  * @param obj - The value being compared.
  * @param ref - The reference value used for comparison.
- * 
+ *
  * @return true when the two values are equal, otherwise false.
  */
 export function deepEqual(obj: any, ref: any, options?: deepEqual.Options): boolean;
@@ -329,6 +329,12 @@ export function reachTemplate(obj: object | null, template: string, options?: re
 export function assert(condition: any, error: Error): void;
 
 
+export class AssertError extends Error {
+
+    constructor(args: (string | Error | any)[]);
+}
+
+
 /**
  * Throw an error if condition is falsy.
  *
@@ -448,9 +454,9 @@ export function block(): Promise<void>;
 
 /**
  * Determines if an object is a promise.
- * 
+ *
  * @param promise - the object tested.
- * 
+ *
  * @returns true if the object is a promise, otherwise false.
  */
 export function isPromise(promise: any): boolean;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ exports.contain = require('./contain');
 
 exports.deepEqual = require('./deepEqual');
 
-exports.Error = require('./error');
+exports.Error = exports.AssertError = require('./error');
 
 exports.escapeHeaderAttribute = require('./escapeHeaderAttribute');
 

--- a/test/esm.js
+++ b/test/esm.js
@@ -20,6 +20,7 @@ describe('import()', () => {
     it('exposes all methods and classes as named imports', () => {
 
         expect(Object.keys(Hoek)).to.equal([
+            'AssertError',
             'Bench',
             'Error',
             'applyToDefaults',


### PR DESCRIPTION
I noticed `Error` is not exposed in the typescript types, I found it weird to export a variable that would be shadowing the global Error, I thought it was a better idea to have a proper name so we can slowly transition to that to avoid any further confusion, let me know what you think.