### PR TITLE
chore: add individual module types

### DIFF
--- a/lib/applyToDefaults.d.ts
+++ b/lib/applyToDefaults.d.ts
@@ -1,0 +1,3 @@
+import { applyToDefaults } from "./index";
+
+export = applyToDefaults;

--- a/lib/assert.d.ts
+++ b/lib/assert.d.ts
@@ -1,0 +1,3 @@
+import { assert } from "./index";
+
+export = assert;

--- a/lib/assertError.d.ts
+++ b/lib/assertError.d.ts
@@ -1,0 +1,3 @@
+import { AssertError } from "./index";
+
+export = AssertError;

--- a/lib/bench.d.ts
+++ b/lib/bench.d.ts
@@ -1,0 +1,3 @@
+import { Bench } from "./index";
+
+export = Bench;

--- a/lib/block.d.ts
+++ b/lib/block.d.ts
@@ -1,0 +1,3 @@
+import { block } from "./index";
+
+export = block;

--- a/lib/clone.d.ts
+++ b/lib/clone.d.ts
@@ -1,0 +1,3 @@
+import { clone } from "./index";
+
+export = clone;

--- a/lib/contain.d.ts
+++ b/lib/contain.d.ts
@@ -1,0 +1,3 @@
+import { contain } from "./index";
+
+export = contain;

--- a/lib/deepEqual.d.ts
+++ b/lib/deepEqual.d.ts
@@ -1,0 +1,3 @@
+import { deepEqual } from "./index";
+
+export = deepEqual;

--- a/lib/escapeHeaderAttribute.d.ts
+++ b/lib/escapeHeaderAttribute.d.ts
@@ -1,0 +1,3 @@
+import { escapeHeaderAttribute } from "./index";
+
+export = escapeHeaderAttribute;

--- a/lib/escapeHtml.d.ts
+++ b/lib/escapeHtml.d.ts
@@ -1,0 +1,3 @@
+import { escapeHtml } from "./index";
+
+export = escapeHtml;

--- a/lib/escapeJson.d.ts
+++ b/lib/escapeJson.d.ts
@@ -1,0 +1,3 @@
+import { escapeJson } from "./index";
+
+export = escapeJson;

--- a/lib/escapeRegex.d.ts
+++ b/lib/escapeRegex.d.ts
@@ -1,0 +1,3 @@
+import { escapeRegex } from "./index";
+
+export = escapeRegex;

--- a/lib/flatten.d.ts
+++ b/lib/flatten.d.ts
@@ -1,0 +1,3 @@
+import { flatten } from "./index";
+
+export = flatten;

--- a/lib/ignore.d.ts
+++ b/lib/ignore.d.ts
@@ -1,0 +1,3 @@
+import { ignore } from "./index";
+
+export = ignore;

--- a/lib/intersect.d.ts
+++ b/lib/intersect.d.ts
@@ -1,0 +1,3 @@
+import { intersect } from "./index";
+
+export = intersect;

--- a/lib/isPromise.d.ts
+++ b/lib/isPromise.d.ts
@@ -1,0 +1,3 @@
+import { isPromise } from "./index";
+
+export = isPromise;

--- a/lib/merge.d.ts
+++ b/lib/merge.d.ts
@@ -1,0 +1,3 @@
+import { merge } from "./index";
+
+export = merge;

--- a/lib/once.d.ts
+++ b/lib/once.d.ts
@@ -1,0 +1,3 @@
+import { once } from "./index";
+
+export = once;

--- a/lib/reach.d.ts
+++ b/lib/reach.d.ts
@@ -1,0 +1,3 @@
+import { reach } from "./index";
+
+export = reach;

--- a/lib/reachTemplate.d.ts
+++ b/lib/reachTemplate.d.ts
@@ -1,0 +1,3 @@
+import { reachTemplate } from "./index";
+
+export = reachTemplate;

--- a/lib/stringify.d.ts
+++ b/lib/stringify.d.ts
@@ -1,0 +1,3 @@
+import { stringify } from "./index";
+
+export = stringify;

--- a/lib/wait.d.ts
+++ b/lib/wait.d.ts
@@ -1,0 +1,3 @@
+import { wait } from "./index";
+
+export = wait;

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,9 +1,13 @@
 import * as Hoek from '..';
 import * as Lab from '@hapi/lab';
+import deepEqual = require('../lib/deepEqual');
 
 
 const { expect } = Lab.types;
 
+// Direct module import
+expect.type<Function>(deepEqual);
+expect.type<boolean>(deepEqual(1, 2));
 
 interface Foo {
     a?: number;


### PR DESCRIPTION
When importing individual modules, types are not automatically taken from the central types, we need to re-export those.