### PR TITLE
fix: provide reference to TS types for export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./lib/index.mjs",
-      "require": "./lib/index.js"
+      "require": "./lib/index.js",
+      "types": "./lib/index.d.ts"
     },
     "./applyToDefaults": "./lib/applyToDefaults.js",
     "./assert": "./lib/assert.js",


### PR DESCRIPTION
I have the same issue as described [here](https://github.com/hapijs/hoek/issues/385). This PR fix reference to TS types for export map. After these changes, my TS project with `node v20` and the default settings from `@tsconfig/node20/tsconfig.json` works as expected. In `package.json` mention `"type": "module"`.