### PR TITLE
Custom error cloning to fix node v21 issue

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -88,6 +88,12 @@ module.exports = internals.clone = function (obj, options = {}, _seen = null) {
             continue;
         }
 
+        if (baseProto === Types.error &&
+            (key === 'message' || key === 'stack')) {
+
+            continue;       // Already a part of the base object
+        }
+
         const descriptor = Object.getOwnPropertyDescriptor(obj, key);
         if (descriptor) {
             if (descriptor.get ||
@@ -161,6 +167,14 @@ internals.base = function (obj, baseProto, options) {
         }
 
         return newObj;
+    }
+    else if (baseProto === Types.error) {
+        const err = structuredClone(obj);                    // Needed to copy internal stack state
+        if (proto !== baseProto) {
+            Object.setPrototypeOf(err, proto);               // Fix prototype
+        }
+
+        return err;
     }
 
     if (internals.needsProtoHack.has(baseProto)) {

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -89,7 +89,7 @@ module.exports = internals.clone = function (obj, options = {}, _seen = null) {
         }
 
         if (baseProto === Types.error &&
-            (key === 'message' || key === 'stack')) {
+            key === 'stack') {
 
             continue;       // Already a part of the base object
         }

--- a/test/clone.js
+++ b/test/clone.js
@@ -680,6 +680,34 @@ describe('clone()', () => {
         expect(b.get(nestedObj)).to.equal(a.get(nestedObj));
     });
 
+    it('clones Error', () => {
+
+        class CustomError extends Error {
+            name = 'CustomError';
+        }
+
+        const a = new CustomError('bad');
+        a.test = Symbol('test');
+
+        const b = Hoek.clone(a);
+
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
+        expect(b).to.be.instanceOf(CustomError);
+        expect(b.stack).to.equal(a.stack);     // Explicitly validate the .stack getters
+    });
+
+    it('cloned Error handles late stack update', () => {
+
+        const a = new Error('bad');
+        const b = Hoek.clone(a);
+
+        a.stack = 'late update';
+
+        expect(b).to.equal(a);
+        expect(b.stack).to.not.equal(a.stack);
+    });
+
     it('ignores symbols', () => {
 
         const sym = Symbol();

--- a/test/clone.js
+++ b/test/clone.js
@@ -694,7 +694,32 @@ describe('clone()', () => {
         expect(b).to.equal(a);
         expect(b).to.not.shallow.equal(a);
         expect(b).to.be.instanceOf(CustomError);
-        expect(b.stack).to.equal(a.stack);     // Explicitly validate the .stack getters
+        expect(b.stack).to.equal(a.stack);                 // Explicitly validate the .stack getters
+    });
+
+    it('clones Error with cause', () => {
+
+        const a = new TypeError('bad', { cause: new Error('embedded') });
+        const b = Hoek.clone(a);
+
+        expect(b).to.equal(a);
+        expect(b).to.not.shallow.equal(a);
+        expect(b).to.be.instanceOf(TypeError);
+        expect(b.stack).to.equal(a.stack);                 // Explicitly validate the .stack getters
+        expect(b.cause.stack).to.equal(a.cause.stack);     // Explicitly validate the .stack getters
+    });
+
+    it('clones Error with error message', () => {
+
+        const a = new Error();
+        a.message = new Error('message');
+
+        const b = Hoek.clone(a);
+
+        //expect(b).to.equal(a);                           // deepEqual() always compares message using ===
+        expect(b.message).to.equal(a.message);
+        expect(b.message).to.not.shallow.equal(a.message);
+        expect(b.stack).to.equal(a.stack);
     });
 
     it('cloned Error handles late stack update', () => {


### PR DESCRIPTION
This PR fixes a `Hoek.clone(err)` issue introduced in node v21.

### The problem

Node 21 updates the V8 engine to 11.8, which includes [a patch](https://github.com/v8/v8/commit/79cdd69a1cfa9d3b4d9b6dec7203db4dabe618b4) from v11.5.1 that changes how the `Error.stack` property works.

With this patch, a copied `err.stack` descriptor will no longer return the `stack` of the source error, but always return `undefined`. This breaks Boom, where [it relies on clone() to fully work](https://github.com/hapijs/boom/blob/01a4996dc6e62949aa7a98ca75b2d0dcd8a4a0a8/lib/index.js#L74).

This manifestation of this issue was [reported on discord](https://discord.com/channels/1031830080109957162/1039243211882893312/1167595487860359238).

### The solution

The only way to copy a working stack descriptor in node 21, is to used the [`structuredClone()`](https://nodejs.org/dist/latest-v20.x/docs/api/globals.html#structuredclonevalue-options) method. This is a platform method that uses an algorithm from the [HTML spec](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal) to create a "clone". Only the "name", "message", "cause", and "stack" properties are transferred, and the prototype is set to a standard `Error`. See the [serialization algorithm](https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal) step 17 which deals with `[[ErrorData]]` objects.

I use `structuredClone()` to create the base object, and then pass it through the standard recursive object cloner to clone all properties except the `stack` property. This preserves the existing behaviour, including for weird corner cases.

This PR will only work with node >= v17.0.0, which is when `structuredClone()` was added. Given that every node release <18 is no longer supported, I don't want to spend energy fixing this, and expect that this fix can be part of a new breaking  change release. Or is the current release expected to support node v21?