### PR TITLE
Support the URL type

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -41,16 +41,14 @@ module.exports = internals.clone = function (obj, options = {}, _seen = null) {
     // Built-in object types
 
     const baseProto = Types.getInternalProto(obj);
-    if (baseProto === Types.buffer) {
-        return Buffer && Buffer.from(obj);              // $lab:coverage:ignore$
-    }
-
-    if (baseProto === Types.date) {
-        return new Date(obj.getTime());
-    }
-
-    if (baseProto === Types.regex) {
-        return new RegExp(obj);
+    switch (baseProto) {
+        case Types.buffer:
+            return Buffer?.from(obj);
+        case Types.date:
+            return new Date(obj.getTime());
+        case Types.regex:
+        case Types.url:
+            return new baseProto.constructor(obj);
     }
 
     // Generic objects

--- a/lib/deepEqual.js
+++ b/lib/deepEqual.js
@@ -54,6 +54,7 @@ internals.isDeepEqual = function (obj, ref, options, seen) {
         case Types.promise:
             return obj === ref;
         case Types.regex:
+        case Types.url:
             return obj.toString() === ref.toString();
         case internals.mismatched:
             return false;

--- a/lib/types.js
+++ b/lib/types.js
@@ -13,6 +13,7 @@ exports = module.exports = {
     promise: Promise.prototype,
     regex: RegExp.prototype,
     set: Set.prototype,
+    url: URL.prototype,
     weakMap: WeakMap.prototype,
     weakSet: WeakSet.prototype
 };
@@ -23,6 +24,7 @@ internals.typeMap = new Map([
     ['[object Map]', exports.map],
     ['[object Promise]', exports.promise],
     ['[object Set]', exports.set],
+    ['[object URL]', exports.url],
     ['[object WeakMap]', exports.weakMap],
     ['[object WeakSet]', exports.weakSet]
 ]);

--- a/test/clone.js
+++ b/test/clone.js
@@ -680,6 +680,15 @@ describe('clone()', () => {
         expect(b.get(nestedObj)).to.equal(a.get(nestedObj));
     });
 
+    it('clones an URL', () => {
+
+        const a = new URL('https://hapi.dev/');
+        const b = Hoek.clone(a);
+
+        expect(b.href).to.equal(a.href);
+        expect(b).to.not.shallow.equal(a);
+    });
+
     it('ignores symbols', () => {
 
         const sym = Symbol();

--- a/test/index.js
+++ b/test/index.js
@@ -1154,6 +1154,15 @@ describe('deepEqual()', () => {
         expect(Hoek.deepEqual(a, new Promise(() => { }))).to.be.false();
     });
 
+    it('compares urls', () => {
+
+        const a = new URL('https://hapi.dev/');
+
+        expect(Hoek.deepEqual(a, a)).to.be.true();
+        expect(Hoek.deepEqual(a, new URL('https://hapi.dev/?new'))).to.be.false();
+        expect(Hoek.deepEqual(a, {}, { prototype: false })).to.be.false();
+    });
+
     it('compares buffers', () => {
 
         expect(Hoek.deepEqual(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3]))).to.be.true();


### PR DESCRIPTION
I added support for the `URL` type, both in `Hoek.deepEqual()` and `Hoek.clone()`.

This fixes the issue in https://github.com/hapijs/wreck/issues/305#issuecomment-1828971089.