### PR TITLE
Fix default values for `merge.Options` interface

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -116,14 +116,14 @@ export namespace merge {
         /**
          * When true, array value from `source` is merged with the existing value in `target`.
          *
-         * @default false
+         * @default true
          */
         readonly mergeArrays?: boolean;
 
         /**
          * Compare symbol properties.
          *
-         * @default true
+         * @default undefined
          */
         readonly symbols?: boolean;
     }


### PR DESCRIPTION
Fixes issue https://github.com/hapijs/hoek/issues/395 with typed defaults for `mergeArrays` and `symbols`