### PR TITLE
Fix Error clone() when structuredClone uses bad prototype

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -175,7 +175,7 @@ internals.base = function (obj, baseProto, options) {
     /* $lab:coverage:off$ */
     else if (baseProto === Types.error && internals.structuredCloneExists) {
         const err = structuredClone(obj);                    // Needed to copy internal stack state
-        if (proto !== baseProto) {
+        if (Object.getPrototypeOf(err) !== proto) {
             Object.setPrototypeOf(err, proto);               // Fix prototype
         }
 

--- a/test/clone.js
+++ b/test/clone.js
@@ -886,4 +886,32 @@ describe('clone()', () => {
         const b = Hoek.clone(a);
         expect(b.x).to.not.exist();
     });
+
+    it('handles structuredClone not returning proper Error instances', { skip: typeof structuredClone !== 'function' }, () => {
+
+        // This can happen when running in a VM
+
+        const error = new Error('blam');
+
+        const origStructuredClone = structuredClone;
+        try {
+            structuredClone = function (obj) {
+
+                const clone = origStructuredClone.call(this, obj);
+                if (obj === error) {
+                    Object.setPrototypeOf(clone, Object);
+                }
+
+                return clone;
+            };
+
+            var cloned = Hoek.clone(error);
+        }
+        finally {
+            structuredClone = origStructuredClone;
+        }
+
+        expect(cloned).to.be.instanceOf(Error);
+        expect(cloned).to.equal(error);
+    });
 });


### PR DESCRIPTION
Originally reported in https://github.com/hapijs/hoek/pull/398#discussion_r1814784186.

This can happen in jest which uses node vm to isolate runs.