### PR TITLE
Fix cloning Util.inherit() subclassed errors

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -166,10 +166,12 @@ internals.base = function (obj, baseProto, options) {
 
         return newObj;
     }
-    else if (baseProto === Types.error) {
-        const err = structuredClone(obj);                    // Needed to copy internal stack state
+    else if (baseProto === Types.error &&
+        (proto === baseProto || Error.isPrototypeOf(proto.constructor))) {      // Don't match Util.inherit() subclassed errors
+
+        const err = structuredClone(obj);                                       // Needed to copy internal stack state
         if (Object.getPrototypeOf(err) !== proto) {
-            Object.setPrototypeOf(err, proto);               // Fix prototype
+            Object.setPrototypeOf(err, proto);                                  // Fix prototype
         }
 
         return err;

--- a/test/clone.js
+++ b/test/clone.js
@@ -731,6 +731,35 @@ describe('clone()', () => {
         expect(b.stack).to.equal(a.stack);
     });
 
+    it('clones Error with function property', () => {
+
+        const a = new Error('hello');
+        a.fun = new Function();
+
+        const b = Hoek.clone(a);
+
+        expect(b).to.equal(a);
+        expect(b.stack).to.equal(a.stack);
+    });
+
+    it('clones legacy extended Error with function property', () => {
+
+        const CustomError = function () {
+
+            Error.call(this);
+        };
+
+        Object.setPrototypeOf(CustomError.prototype, Error.prototype);
+
+        const a = new CustomError('hello');
+        a.fun = new Function();
+
+        const b = Hoek.clone(a);
+
+        expect(b).to.equal(a);
+        expect(b.stack).to.equal(a.stack);
+    });
+
     it('cloned Error handles late stack update', () => {
 
         const a = new Error('bad');


### PR DESCRIPTION
This should fix the issue in #400.

`Util.inherits()` (essentially [`Object.setPrototypeOf()` on prototype properties](https://github.com/nodejs/node/blob/be5a500ae39baba2747be1b94972ef8d224fcb49/lib/util.js#L198)) subclassed errors somehow trigger different `structuredClone()` cloning logic than regular ES6 subclassed errors. This seems to be a fallout of the issue in https://github.com/nodejs/node/issues/4179, which found that the prototype chain is not applied.

The fix is to detect these (using a failing `Error.isPrototypeOf(proto.constructor)`), and fallback to the old cloning logic. Incidentally, it seems that custom errors subclassed using `Util.inherits()` continue to preserve the stack using the old logic.